### PR TITLE
Fix env var parsing

### DIFF
--- a/tests/env-vars.spec.js
+++ b/tests/env-vars.spec.js
@@ -450,7 +450,7 @@ describe('toNameEqualsValueString()', () => {
     ].join('\n'));
   });
 
-  test('accept double quotes in values', () => {
+  test('accept double quotes in values (and escape them)', () => {
     const variables = [
       { name: 'NAME_A', value: 'AAA' },
       { name: 'NAME_B', value: `BBBB"BBBB` },
@@ -476,7 +476,7 @@ describe('toNameEqualsValueString()', () => {
     ].join('\n'));
   });
 
-  test('escape line breaks', () => {
+  test('accept line breaks', () => {
     const variables = [
       { name: 'NAME_A', value: `A\na\nA` },
       { name: 'NAME_B', value: 'BBBB' },
@@ -487,7 +487,7 @@ describe('toNameEqualsValueString()', () => {
     ].join('\n'));
   });
 
-  test('escape line breaks (with exports)', () => {
+  test('accept line breaks (with exports)', () => {
     const variables = [
       { name: 'NAME_A', value: `A\na\nA` },
       { name: 'NAME_B', value: 'BBBB' },
@@ -498,7 +498,7 @@ describe('toNameEqualsValueString()', () => {
     ].join('\n'));
   });
 
-  test('escape line breaks and escape double quotes', () => {
+  test('accept line breaks and escape double quotes', () => {
     const variables = [
       { name: 'NAME_A', value: `A\n"a"\nA` },
       { name: 'NAME_B', value: 'BBBB' },


### PR DESCRIPTION
This PR aims to fix several problems with how we serialize and deserialize our env vars in the `KEY="VALUE"` format.

## Problems

### 1. False line breaks

As described in [issue 8](https://github.com/CleverCloud/clever-client.js/issues/8), when a variable value contains a slash followed by the "n" character, it was handled as a line break when converting it to the `KEY="VALUE"` format.

Example:

With this:

![Capture d’écran_2020-03-06_13-46-52](https://user-images.githubusercontent.com/236342/76084816-14bcf780-5fb1-11ea-8054-78930ef03e06.png)

We got this serialized result:

![Capture d’écran_2020-03-06_13-47-03](https://user-images.githubusercontent.com/236342/76084824-1686bb00-5fb1-11ea-8259-f5c6f4735211.png)

NOTE: The `\n` sequence of characters was recognized as a  new line but an additional slash was added.

This is cased by the fact that we rely on `JSON.stringify()` to escape the whole value before surrounding it by double quotes. Something like this:

```js
const quotedValue = `"${JSON.stringify(value)}"`
```

### 2. Bad parsing

As described in [issue 13](https://github.com/CleverCloud/clever-client.js/issues/13), when a variable value contains already escaped quotes `\"`, it was serialized to `\\\"` properly by `JSON.stringify()` but when `\\\"` was parsed, it was done in a naïve way by our custom code and produced `\\"`.

Example:

With this:

![Capture d’écran_2020-03-06_14-01-37](https://user-images.githubusercontent.com/236342/76085978-6ebebc80-5fb3-11ea-9d04-9343c244a226.png)

We got this serialized result:

![Capture d’écran_2020-03-06_14-01-48](https://user-images.githubusercontent.com/236342/76086059-9d3c9780-5fb3-11ea-97e3-3b00fe8d82d1.png)

And when parsing this serialized result back, we got this:

![Capture d’écran_2020-03-06_14-02-05](https://user-images.githubusercontent.com/236342/76085991-78e0bb00-5fb3-11ea-9213-c7b9df104752.png)

NOTE: This caused problems to some users even without escaped double quotes because `JSON.stringify()` was also escaping slashes and other characters.

Example with a env var value with a regex (slashes and backslashes):

With this:

![Capture d’écran_2020-03-06_14-09-30](https://user-images.githubusercontent.com/236342/76086336-323f9080-5fb4-11ea-8c1e-b4894d7c61df.png)

We got this serialized result:

![Capture d’écran_2020-03-06_14-09-44](https://user-images.githubusercontent.com/236342/76086343-366bae00-5fb4-11ea-9f27-c522285b29ec.png)

NOTE: There is no reason to escape those slashes and back slashes

And when parsing this serialized result back, we got this:

![Capture d’écran_2020-03-06_14-10-03](https://user-images.githubusercontent.com/236342/76086393-497e7e00-5fb4-11ea-98e8-01007293e6e8.png)

## Solution

Here's what we've done:

* For serialization: stop using `JSON.stringify()` and create custom code to only escape double quotes.
* For parsing: custom code to do an exact revert of the serialization

NOTE: You have to be careful with the slashes, the goal is to be able to produce something that a shell script can use (with the export option).

### Breaking change

This solution causes a breaking change for users that saved a text file with the "old" serialization technique.

## Open question

* In the parsing, should we identify and throw error when the number of quotes causes problems?