### PR TITLE
Add GET /self/applications/{appId}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Clever Client changelog
 
+## 5.2.0 (2020-03-30)
+
+* Add `GET /self/applications/{appId}` in `api/application.js` with `getFromSelf()`
+
 ## 5.1.0 (2020-03-27)
 
 * Add `payment` param to `addTcpRedir()` in `api/application`

--- a/data/patch-for-openapi-clever.json
+++ b/data/patch-for-openapi-clever.json
@@ -1274,7 +1274,7 @@
         "method": "get",
         "operationId": "getApplication_1",
         "x-service": "application",
-        "x-function": "get"
+        "x-function": "getFromSelf"
     },
     {
         "path": "/self/applications/{appId}",


### PR DESCRIPTION
It was shadowed by the /organisations counterpart with the same name