### PR TITLE
Add /v4/addon-providers/jenkins/addons/{addonId}/updates endpoint

### DIFF
--- a/data/openapi-clever-v4.json
+++ b/data/openapi-clever-v4.json
@@ -56,7 +56,24 @@
         "x-function": "getAddon"
       }
     },
-	"/addon-providers/{providerId}/clusters/{clusterId}": {
+    "/addon-providers/jenkins/addons/{addonId}/updates": {
+      "get": {
+        "operationId": "getJenkinsUpdates",
+        "parameters": [
+          { "name": "addonId", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": { }
+            }
+          }
+        },
+        "x-service": "addon-providers",
+        "x-function": "getJenkinsUpdates"
+      }
+    },
+    "/addon-providers/{providerId}/clusters/{clusterId}": {
       "get": {
         "operationId": "getCluster",
         "parameters": [


### PR DESCRIPTION
This adds a new `/v4/` route at `/v4/addon-providers/jenkins/addons/{addonId}/updates` that will be used to `GET` available updates of a Jenkins add-on.

Other add-ons might need this route later too but for now, unless jenkins, it won't be implemented for the other providers. That's why I hardcoded `jenkins` in here instead of using `{providerId}`.

What do you think?