### PR TITLE
refactor(diag-domain-config.types): remove `private` from `DiagSummary`

### DIFF
--- a/esm/utils/diag-domain-config.types.d.ts
+++ b/esm/utils/diag-domain-config.types.d.ts
@@ -30,8 +30,7 @@ export type DiagSummary =
   | "no-config"
   | "invalid"
   | "incomplete"
-  | "valid"
-  | "private";
+  | "valid";
 
 export interface RecordDiag {
   code:


### PR DESCRIPTION
## What does this PR do?

- Removes the `private` value from the union type `DiagSummary` because it is not used.