### PR TITLE
fix: correctly rebuild apps

### DIFF
--- a/src/clients/cc-api/commands/application/deploy-application-command.js
+++ b/src/clients/cc-api/commands/application/deploy-application-command.js
@@ -21,7 +21,7 @@ export class DeployApplicationCommand extends CcApiSimpleCommand {
       null,
       new QueryParams({
         commit: params.commit,
-        useCache: params.useCache,
+        useCache: params.useCache === false ? 'no' : null,
       }),
     );
   }


### PR DESCRIPTION
The new client uses a boolean for `useCache` in application deployment payload, but the API only manages the `no` value. As the boolean approach is more user friendly, I kept it and only pass `no` to the API when it's `false`.