### PR TITLE
fix: add missing package-lock update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
         "typescript": "^5.8.3"
       },
       "engines": {
-        "node": "22"
+        "node": ">=22"
       },
       "peerDependencies": {
         "eventsource": "^4.0.0"


### PR DESCRIPTION
## What does this PR do?

On `master` right now, if you run `npm i`, the `package-lock.json` is updated because it wasn't committed with the last changes.

This PR commits the `package-lock.json` change.