### PR TITLE
Add Operator commands

### DIFF
--- a/src/clients/cc-api/commands/keycloak/check-keycloak-version-command.js
+++ b/src/clients/cc-api/commands/keycloak/check-keycloak-version-command.js
@@ -1,0 +1,37 @@
+/**
+ * @import { CheckKeycloakVersionCommandInput, CheckKeycloakVersionCommandOutput } from './check-keycloak-version-command.types.js';
+ */
+import { get } from '../../../../lib/request/request-params-builder.js';
+import { safeUrl } from '../../../../lib/utils.js';
+import { CcApiSimpleCommand } from '../../lib/cc-api-command.js';
+
+/**
+ *
+ * @extends {CcApiSimpleCommand<CheckKeycloakVersionCommandInput, CheckKeycloakVersionCommandOutput>}
+ * @endpoint [GET] /v4/addon-providers/addon-keycloak/addons/:XXX/version/check
+ * @group Keycloak
+ * @version 4
+ */
+export class CheckKeycloakVersionCommand extends CcApiSimpleCommand {
+  /** @type {CcApiSimpleCommand<CheckKeycloakVersionCommandInput, CheckKeycloakVersionCommandOutput>['toRequestParams']} */
+  toRequestParams(params) {
+    return get(safeUrl`/v4/addon-providers/addon-keycloak/addons/${params.addonId}/version/check`);
+  }
+
+  /** @type {CcApiSimpleCommand<?, ?>['getIdsToResolve']} */
+  getIdsToResolve() {
+    return {
+      addonId: 'REAL_ADDON_ID',
+    };
+  }
+
+  /** @type {CcApiSimpleCommand<CheckKeycloakVersionCommandInput, CheckKeycloakVersionCommandOutput>['transformCommandOutput']} */
+  transformCommandOutput(response) {
+    return {
+      installed: response.installed,
+      available: response.available,
+      latest: response.latest,
+      needUpdate: response.needUpdate,
+    };
+  }
+}

--- a/src/clients/cc-api/commands/keycloak/check-keycloak-version-command.types.d.ts
+++ b/src/clients/cc-api/commands/keycloak/check-keycloak-version-command.types.d.ts
@@ -1,0 +1,10 @@
+export type CheckKeycloakVersionCommandInput = {
+  addonId: string;
+};
+
+export type CheckKeycloakVersionCommandOutput = {
+  installed: string;
+  available: Array<string>;
+  latest: string;
+  needUpdate: boolean;
+};

--- a/src/clients/cc-api/commands/keycloak/create-keycloak-network-group-command.js
+++ b/src/clients/cc-api/commands/keycloak/create-keycloak-network-group-command.js
@@ -1,0 +1,33 @@
+/**
+ * @import { CreateKeycloakNetworkGroupCommandInput, CreateKeycloakNetworkGroupCommandOutput } from './create-keycloak-network-group-command.types.js';
+ */
+import { post } from '../../../../lib/request/request-params-builder.js';
+import { safeUrl } from '../../../../lib/utils.js';
+import { CcApiSimpleCommand } from '../../lib/cc-api-command.js';
+import { transformKeycloakInfo } from './keycloak-transform.js';
+
+/**
+ *
+ * @extends {CcApiSimpleCommand<CreateKeycloakNetworkGroupCommandInput, CreateKeycloakNetworkGroupCommandOutput>}
+ * @endpoint [POST] /v4/addon-providers/addon-keycloak/addons/:XXX/networkgroup
+ * @group Keycloak
+ * @version 4
+ */
+export class CreateKeycloakNetworkGroupCommand extends CcApiSimpleCommand {
+  /** @type {CcApiSimpleCommand<CreateKeycloakNetworkGroupCommandInput, CreateKeycloakNetworkGroupCommandOutput>['toRequestParams']} */
+  toRequestParams(params) {
+    return post(safeUrl`/v4/addon-providers/addon-keycloak/addons/${params.addonId}/networkgroup`);
+  }
+
+  /** @type {CcApiSimpleCommand<?, ?>['getIdsToResolve']} */
+  getIdsToResolve() {
+    return {
+      addonId: 'REAL_ADDON_ID',
+    };
+  }
+
+  /** @type {CcApiSimpleCommand<CreateKeycloakNetworkGroupCommandInput, CreateKeycloakNetworkGroupCommandOutput>['transformCommandOutput']} */
+  transformCommandOutput(response) {
+    return transformKeycloakInfo(response);
+  }
+}

--- a/src/clients/cc-api/commands/keycloak/create-keycloak-network-group-command.types.d.ts
+++ b/src/clients/cc-api/commands/keycloak/create-keycloak-network-group-command.types.d.ts
@@ -1,0 +1,7 @@
+import type { KeycloakInfo } from './keycloak.types.js';
+
+export type CreateKeycloakNetworkGroupCommandInput = {
+  addonId: string;
+};
+
+export type CreateKeycloakNetworkGroupCommandOutput = KeycloakInfo;

--- a/src/clients/cc-api/commands/keycloak/delete-keycloak-network-group-command.js
+++ b/src/clients/cc-api/commands/keycloak/delete-keycloak-network-group-command.js
@@ -1,0 +1,32 @@
+/**
+ * @import { DeleteKeycloakNetworkGroupCommandInput } from './delete-keycloak-network-group-command.types.js';
+ */
+import { delete_ } from '../../../../lib/request/request-params-builder.js';
+import { safeUrl } from '../../../../lib/utils.js';
+import { CcApiSimpleCommand } from '../../lib/cc-api-command.js';
+
+/**
+ *
+ * @extends {CcApiSimpleCommand<DeleteKeycloakNetworkGroupCommandInput, void>}
+ * @endpoint [DELETE] /v4/addon-providers/addon-keycloak/addons/:XXX/networkgroup
+ * @group Keycloak
+ * @version 4
+ */
+export class DeleteKeycloakNetworkGroupCommand extends CcApiSimpleCommand {
+  /** @type {CcApiSimpleCommand<DeleteKeycloakNetworkGroupCommandInput, void>['toRequestParams']} */
+  toRequestParams(params) {
+    return delete_(safeUrl`/v4/addon-providers/addon-keycloak/addons/${params.addonId}/networkgroup`);
+  }
+
+  /** @type {CcApiSimpleCommand<?, ?>['getIdsToResolve']} */
+  getIdsToResolve() {
+    return {
+      addonId: 'REAL_ADDON_ID',
+    };
+  }
+
+  /** @type {CcApiSimpleCommand<DeleteKeycloakNetworkGroupCommandInput, void>['transformCommandOutput']} */
+  transformCommandOutput() {
+    return null;
+  }
+}

--- a/src/clients/cc-api/commands/keycloak/delete-keycloak-network-group-command.types.d.ts
+++ b/src/clients/cc-api/commands/keycloak/delete-keycloak-network-group-command.types.d.ts
@@ -1,0 +1,3 @@
+export type DeleteKeycloakNetworkGroupCommandInput = {
+  addonId: string;
+};

--- a/src/clients/cc-api/commands/keycloak/get-keycloak-info-command.js
+++ b/src/clients/cc-api/commands/keycloak/get-keycloak-info-command.js
@@ -1,0 +1,38 @@
+/**
+ * @import { GetKeycloakInfoCommandInput, GetKeycloakInfoCommandOutput } from './get-keycloak-info-command.types.js';
+ */
+import { get } from '../../../../lib/request/request-params-builder.js';
+import { safeUrl } from '../../../../lib/utils.js';
+import { CcApiSimpleCommand } from '../../lib/cc-api-command.js';
+import { transformKeycloakInfo } from './keycloak-transform.js';
+
+/**
+ *
+ * @extends {CcApiSimpleCommand<GetKeycloakInfoCommandInput, GetKeycloakInfoCommandOutput>}
+ * @endpoint [GET] /v4/addon-providers/addon-keycloak/addons/:XXX
+ * @group Keycloak
+ * @version 4
+ */
+export class GetKeycloakInfoCommand extends CcApiSimpleCommand {
+  /** @type {CcApiSimpleCommand<GetKeycloakInfoCommandInput, GetKeycloakInfoCommandOutput>['toRequestParams']} */
+  toRequestParams(params) {
+    return get(safeUrl`/v4/addon-providers/addon-keycloak/addons/${params.addonId}`);
+  }
+
+  /** @type {CcApiSimpleCommand<?, ?>['getEmptyResponsePolicy']} */
+  getEmptyResponsePolicy(status) {
+    return { isEmpty: status === 404 };
+  }
+
+  /** @type {CcApiSimpleCommand<?, ?>['getIdsToResolve']} */
+  getIdsToResolve() {
+    return {
+      addonId: 'REAL_ADDON_ID',
+    };
+  }
+
+  /** @type {CcApiSimpleCommand<GetKeycloakInfoCommandInput, GetKeycloakInfoCommandOutput>['transformCommandOutput']} */
+  transformCommandOutput(response) {
+    return transformKeycloakInfo(response);
+  }
+}

--- a/src/clients/cc-api/commands/keycloak/get-keycloak-info-command.types.d.ts
+++ b/src/clients/cc-api/commands/keycloak/get-keycloak-info-command.types.d.ts
@@ -1,0 +1,7 @@
+import type { KeycloakInfo } from './keycloak.types.js';
+
+export type GetKeycloakInfoCommandInput = {
+  addonId: string;
+};
+
+export type GetKeycloakInfoCommandOutput = KeycloakInfo;

--- a/src/clients/cc-api/commands/keycloak/keycloak-transform.js
+++ b/src/clients/cc-api/commands/keycloak/keycloak-transform.js
@@ -1,0 +1,28 @@
+/**
+ * @import { KeycloakInfo } from './keycloak.types.js';
+ */
+
+import { sortBy } from '../../../../lib/utils.js';
+import { toArray } from '../../../../utils/environment-utils.js';
+
+/**
+ * @param {any} response
+ * @returns {KeycloakInfo}
+ */
+export function transformKeycloakInfo(response) {
+  return {
+    id: response.resourceId,
+    addonId: response.addonId,
+    name: response.name,
+    ownerId: response.ownerId,
+    plan: response.plan,
+    version: response.version,
+    javaVersion: response.javaVersion,
+    accessUrl: response.accessUrl,
+    availableVersions: response.availableVersions,
+    resources: response.resources,
+    features: response.features,
+    initialCredentials: response.initialCredentials,
+    environment: sortBy(toArray(response.envVars), 'name'),
+  };
+}

--- a/src/clients/cc-api/commands/keycloak/keycloak.types.d.ts
+++ b/src/clients/cc-api/commands/keycloak/keycloak.types.d.ts
@@ -1,0 +1,26 @@
+import { EnvironmentVariable } from '../../../../utils/environment.types.js';
+
+export interface KeycloakInfo {
+  id: string;
+  addonId: string;
+  name: string;
+  ownerId: string;
+  plan: string;
+  version: string;
+  javaVersion: string;
+  accessUrl: string;
+  initialCredentials: {
+    user: string;
+    password: string;
+  };
+  availableVersions: string[];
+  resources: {
+    entrypoint: string;
+    fsbucketId: string;
+    pgsqlId: string;
+  };
+  features: {
+    networkGroup?: { id: string };
+  };
+  environment: Array<EnvironmentVariable>;
+}

--- a/src/clients/cc-api/commands/keycloak/reboot-keycloak-command.js
+++ b/src/clients/cc-api/commands/keycloak/reboot-keycloak-command.js
@@ -1,0 +1,32 @@
+/**
+ * @import { RebootKeycloakCommandInput } from './reboot-keycloak-command.types.js';
+ */
+import { post } from '../../../../lib/request/request-params-builder.js';
+import { safeUrl } from '../../../../lib/utils.js';
+import { CcApiSimpleCommand } from '../../lib/cc-api-command.js';
+
+/**
+ *
+ * @extends {CcApiSimpleCommand<RebootKeycloakCommandInput, void>}
+ * @endpoint [POST] /v4/addon-providers/addon-keycloak/addons/:XXX/reboot
+ * @group Keycloak
+ * @version 4
+ */
+export class RebootKeycloakCommand extends CcApiSimpleCommand {
+  /** @type {CcApiSimpleCommand<RebootKeycloakCommandInput, void>['toRequestParams']} */
+  toRequestParams(params) {
+    return post(safeUrl`/v4/addon-providers/addon-keycloak/addons/${params.addonId}/reboot`);
+  }
+
+  /** @type {CcApiSimpleCommand<?, ?>['getIdsToResolve']} */
+  getIdsToResolve() {
+    return {
+      addonId: 'REAL_ADDON_ID',
+    };
+  }
+
+  /** @type {CcApiSimpleCommand<RebootKeycloakCommandInput, void>['transformCommandOutput']} */
+  transformCommandOutput() {
+    return null;
+  }
+}

--- a/src/clients/cc-api/commands/keycloak/reboot-keycloak-command.types.d.ts
+++ b/src/clients/cc-api/commands/keycloak/reboot-keycloak-command.types.d.ts
@@ -1,0 +1,3 @@
+export type RebootKeycloakCommandInput = {
+  addonId: string;
+};

--- a/src/clients/cc-api/commands/keycloak/rebuild-keycloak-command.js
+++ b/src/clients/cc-api/commands/keycloak/rebuild-keycloak-command.js
@@ -1,0 +1,32 @@
+/**
+ * @import { RebuildKeycloakCommandInput } from './rebuild-keycloak-command.types.js';
+ */
+import { post } from '../../../../lib/request/request-params-builder.js';
+import { safeUrl } from '../../../../lib/utils.js';
+import { CcApiSimpleCommand } from '../../lib/cc-api-command.js';
+
+/**
+ *
+ * @extends {CcApiSimpleCommand<RebuildKeycloakCommandInput, void>}
+ * @endpoint [POST] /v4/addon-providers/addon-keycloak/addons/:XXX/rebuild
+ * @group Keycloak
+ * @version 4
+ */
+export class RebuildKeycloakCommand extends CcApiSimpleCommand {
+  /** @type {CcApiSimpleCommand<RebuildKeycloakCommandInput, void>['toRequestParams']} */
+  toRequestParams(params) {
+    return post(safeUrl`/v4/addon-providers/addon-keycloak/addons/${params.addonId}/rebuild`);
+  }
+
+  /** @type {CcApiSimpleCommand<?, ?>['getIdsToResolve']} */
+  getIdsToResolve() {
+    return {
+      addonId: 'REAL_ADDON_ID',
+    };
+  }
+
+  /** @type {CcApiSimpleCommand<RebuildKeycloakCommandInput, void>['transformCommandOutput']} */
+  transformCommandOutput() {
+    return null;
+  }
+}

--- a/src/clients/cc-api/commands/keycloak/rebuild-keycloak-command.types.d.ts
+++ b/src/clients/cc-api/commands/keycloak/rebuild-keycloak-command.types.d.ts
@@ -1,0 +1,3 @@
+export type RebuildKeycloakCommandInput = {
+  addonId: string;
+};

--- a/src/clients/cc-api/commands/keycloak/update-keycloak-version-command.js
+++ b/src/clients/cc-api/commands/keycloak/update-keycloak-version-command.js
@@ -1,0 +1,35 @@
+/**
+ * @import { UpdateKeycloakVersionCommandInput, UpdateKeycloakVersionCommandOutput } from './update-keycloak-version-command.types.js';
+ */
+import { postJson } from '../../../../lib/request/request-params-builder.js';
+import { safeUrl } from '../../../../lib/utils.js';
+import { CcApiSimpleCommand } from '../../lib/cc-api-command.js';
+import { transformKeycloakInfo } from './keycloak-transform.js';
+
+/**
+ *
+ * @extends {CcApiSimpleCommand<UpdateKeycloakVersionCommandInput, UpdateKeycloakVersionCommandOutput>}
+ * @endpoint [POST] /v4/addon-providers/addon-keycloak/addons/:XXX/version/update
+ * @group Keycloak
+ * @version 4
+ */
+export class UpdateKeycloakVersionCommand extends CcApiSimpleCommand {
+  /** @type {CcApiSimpleCommand<UpdateKeycloakVersionCommandInput, UpdateKeycloakVersionCommandOutput>['toRequestParams']} */
+  toRequestParams(params) {
+    return postJson(safeUrl`/v4/addon-providers/addon-keycloak/addons/${params.addonId}/version/update`, {
+      targetVersion: params.targetVersion,
+    });
+  }
+
+  /** @type {CcApiSimpleCommand<?, ?>['getIdsToResolve']} */
+  getIdsToResolve() {
+    return {
+      addonId: 'REAL_ADDON_ID',
+    };
+  }
+
+  /** @type {CcApiSimpleCommand<UpdateKeycloakVersionCommandInput, UpdateKeycloakVersionCommandOutput>['transformCommandOutput']} */
+  transformCommandOutput(response) {
+    return transformKeycloakInfo(response);
+  }
+}

--- a/src/clients/cc-api/commands/keycloak/update-keycloak-version-command.types.d.ts
+++ b/src/clients/cc-api/commands/keycloak/update-keycloak-version-command.types.d.ts
@@ -1,0 +1,8 @@
+import type { KeycloakInfo } from './keycloak.types.js';
+
+export type UpdateKeycloakVersionCommandInput = {
+  addonId: string;
+  targetVersion: string;
+};
+
+export type UpdateKeycloakVersionCommandOutput = KeycloakInfo;

--- a/src/clients/cc-api/commands/matomo/get-matomo-info-command.js
+++ b/src/clients/cc-api/commands/matomo/get-matomo-info-command.js
@@ -9,7 +9,7 @@ import { CcApiSimpleCommand } from '../../lib/cc-api-command.js';
 /**
  *
  * @extends {CcApiSimpleCommand<GetMatomoInfoCommandInput, GetMatomoInfoCommandOutput>}
- * @endpoint [GET] /v4/addon-providers/:XXX/addons/:XXX
+ * @endpoint [GET] /v4/addon-providers/addon-matomo/addons/:XXX
  * @group Matomo
  * @version 4
  */
@@ -42,7 +42,7 @@ export class GetMatomoInfoCommand extends CcApiSimpleCommand {
       version: response.version,
       phpVersion: response.phpVersion,
       accessUrl: response.accessUrl,
-      availableVersions: response.availableVersions?.sort(),
+      availableVersions: response.availableVersions,
       resources: response.resources,
       environment: sortBy(toArray(response.envVars), 'name'),
     };

--- a/src/clients/cc-api/commands/matomo/matomo.types.d.ts
+++ b/src/clients/cc-api/commands/matomo/matomo.types.d.ts
@@ -15,6 +15,7 @@ export interface MatomoInfo {
     entrypoint: string;
     mysqlId: string;
     redisId: string;
+    kvId?: string;
   };
   // renamed from envVars. transformed from Record<string, string> to Array<EnvironmentVariable>
   environment: Array<EnvironmentVariable>;

--- a/src/clients/cc-api/commands/matomo/reboot-matomo-command.js
+++ b/src/clients/cc-api/commands/matomo/reboot-matomo-command.js
@@ -1,0 +1,32 @@
+/**
+ * @import { RebootMatomoCommandInput } from './reboot-matomo-command.types.js';
+ */
+import { post } from '../../../../lib/request/request-params-builder.js';
+import { safeUrl } from '../../../../lib/utils.js';
+import { CcApiSimpleCommand } from '../../lib/cc-api-command.js';
+
+/**
+ *
+ * @extends {CcApiSimpleCommand<RebootMatomoCommandInput, void>}
+ * @endpoint [POST] /v4/addon-providers/addon-matomo/addons/:XXX/reboot
+ * @group Matomo
+ * @version 4
+ */
+export class RebootMatomoCommand extends CcApiSimpleCommand {
+  /** @type {CcApiSimpleCommand<RebootMatomoCommandInput, void>['toRequestParams']} */
+  toRequestParams(params) {
+    return post(safeUrl`/v4/addon-providers/addon-matomo/addons/${params.addonId}/reboot`);
+  }
+
+  /** @type {CcApiSimpleCommand<?, ?>['getIdsToResolve']} */
+  getIdsToResolve() {
+    return {
+      addonId: 'REAL_ADDON_ID',
+    };
+  }
+
+  /** @type {CcApiSimpleCommand<RebootMatomoCommandInput, void>['transformCommandOutput']} */
+  transformCommandOutput() {
+    return null;
+  }
+}

--- a/src/clients/cc-api/commands/matomo/reboot-matomo-command.types.d.ts
+++ b/src/clients/cc-api/commands/matomo/reboot-matomo-command.types.d.ts
@@ -1,0 +1,3 @@
+export type RebootMatomoCommandInput = {
+  addonId: string;
+};

--- a/src/clients/cc-api/commands/matomo/rebuild-matomo-command.js
+++ b/src/clients/cc-api/commands/matomo/rebuild-matomo-command.js
@@ -1,0 +1,32 @@
+/**
+ * @import { RebuildMatomoCommandInput } from './rebuild-matomo-command.types.js';
+ */
+import { post } from '../../../../lib/request/request-params-builder.js';
+import { safeUrl } from '../../../../lib/utils.js';
+import { CcApiSimpleCommand } from '../../lib/cc-api-command.js';
+
+/**
+ *
+ * @extends {CcApiSimpleCommand<RebuildMatomoCommandInput, void>}
+ * @endpoint [POST] /v4/addon-providers/addon-matomo/addons/:XXX/rebuild
+ * @group Matomo
+ * @version 4
+ */
+export class RebuildMatomoCommand extends CcApiSimpleCommand {
+  /** @type {CcApiSimpleCommand<RebuildMatomoCommandInput, void>['toRequestParams']} */
+  toRequestParams(params) {
+    return post(safeUrl`/v4/addon-providers/addon-matomo/addons/${params.addonId}/rebuild`);
+  }
+
+  /** @type {CcApiSimpleCommand<?, ?>['getIdsToResolve']} */
+  getIdsToResolve() {
+    return {
+      addonId: 'REAL_ADDON_ID',
+    };
+  }
+
+  /** @type {CcApiSimpleCommand<RebuildMatomoCommandInput, void>['transformCommandOutput']} */
+  transformCommandOutput() {
+    return null;
+  }
+}

--- a/src/clients/cc-api/commands/matomo/rebuild-matomo-command.types.d.ts
+++ b/src/clients/cc-api/commands/matomo/rebuild-matomo-command.types.d.ts
@@ -1,0 +1,3 @@
+export type RebuildMatomoCommandInput = {
+  addonId: string;
+};

--- a/src/clients/cc-api/commands/metabase/check-metabase-version-command.js
+++ b/src/clients/cc-api/commands/metabase/check-metabase-version-command.js
@@ -1,0 +1,37 @@
+/**
+ * @import { CheckMetabaseVersionCommandInput, CheckMetabaseVersionCommandOutput } from './check-metabase-version-command.types.js';
+ */
+import { get } from '../../../../lib/request/request-params-builder.js';
+import { safeUrl } from '../../../../lib/utils.js';
+import { CcApiSimpleCommand } from '../../lib/cc-api-command.js';
+
+/**
+ *
+ * @extends {CcApiSimpleCommand<CheckMetabaseVersionCommandInput, CheckMetabaseVersionCommandOutput>}
+ * @endpoint [GET] /v4/addon-providers/addon-metabase/addons/:XXX/version/check
+ * @group Metabase
+ * @version 4
+ */
+export class CheckMetabaseVersionCommand extends CcApiSimpleCommand {
+  /** @type {CcApiSimpleCommand<CheckMetabaseVersionCommandInput, CheckMetabaseVersionCommandOutput>['toRequestParams']} */
+  toRequestParams(params) {
+    return get(safeUrl`/v4/addon-providers/addon-metabase/addons/${params.addonId}/version/check`);
+  }
+
+  /** @type {CcApiSimpleCommand<?, ?>['getIdsToResolve']} */
+  getIdsToResolve() {
+    return {
+      addonId: 'REAL_ADDON_ID',
+    };
+  }
+
+  /** @type {CcApiSimpleCommand<CheckMetabaseVersionCommandInput, CheckMetabaseVersionCommandOutput>['transformCommandOutput']} */
+  transformCommandOutput(response) {
+    return {
+      installed: response.installed,
+      available: response.available,
+      needUpdate: response.needUpdate,
+      latest: response.latest,
+    };
+  }
+}

--- a/src/clients/cc-api/commands/metabase/check-metabase-version-command.types.d.ts
+++ b/src/clients/cc-api/commands/metabase/check-metabase-version-command.types.d.ts
@@ -1,0 +1,10 @@
+export type CheckMetabaseVersionCommandInput = {
+  addonId: string;
+};
+
+export type CheckMetabaseVersionCommandOutput = {
+  installed: string;
+  available: Array<string>;
+  latest: string;
+  needUpdate: boolean;
+};

--- a/src/clients/cc-api/commands/metabase/get-metabase-info-command.js
+++ b/src/clients/cc-api/commands/metabase/get-metabase-info-command.js
@@ -1,0 +1,38 @@
+/**
+ * @import { GetMetabaseInfoCommandInput, GetMetabaseInfoCommandOutput } from './get-metabase-info-command.types.js';
+ */
+import { get } from '../../../../lib/request/request-params-builder.js';
+import { safeUrl } from '../../../../lib/utils.js';
+import { CcApiSimpleCommand } from '../../lib/cc-api-command.js';
+import { transformMetabaseInfo } from './metabase-transform.js';
+
+/**
+ *
+ * @extends {CcApiSimpleCommand<GetMetabaseInfoCommandInput, GetMetabaseInfoCommandOutput>}
+ * @endpoint [GET] /v4/addon-providers/addon-metabase/addons/:XXX
+ * @group Metabase
+ * @version 4
+ */
+export class GetMetabaseInfoCommand extends CcApiSimpleCommand {
+  /** @type {CcApiSimpleCommand<GetMetabaseInfoCommandInput, GetMetabaseInfoCommandOutput>['toRequestParams']} */
+  toRequestParams(params) {
+    return get(safeUrl`/v4/addon-providers/addon-metabase/addons/${params.addonId}`);
+  }
+
+  /** @type {CcApiSimpleCommand<?, ?>['getIdsToResolve']} */
+  getIdsToResolve() {
+    return {
+      addonId: 'REAL_ADDON_ID',
+    };
+  }
+
+  /** @type {CcApiSimpleCommand<?, ?>['getEmptyResponsePolicy']} */
+  getEmptyResponsePolicy(status) {
+    return { isEmpty: status === 404 };
+  }
+
+  /** @type {CcApiSimpleCommand<GetMetabaseInfoCommandInput, GetMetabaseInfoCommandOutput>['transformCommandOutput']} */
+  transformCommandOutput(response) {
+    return transformMetabaseInfo(response);
+  }
+}

--- a/src/clients/cc-api/commands/metabase/get-metabase-info-command.types.d.ts
+++ b/src/clients/cc-api/commands/metabase/get-metabase-info-command.types.d.ts
@@ -1,0 +1,7 @@
+import type { MetabaseInfo } from './metabase.types.js';
+
+export type GetMetabaseInfoCommandInput = {
+  addonId: string;
+};
+
+export type GetMetabaseInfoCommandOutput = MetabaseInfo;

--- a/src/clients/cc-api/commands/metabase/metabase-transform.js
+++ b/src/clients/cc-api/commands/metabase/metabase-transform.js
@@ -1,0 +1,26 @@
+/**
+ * @import { MetabaseInfo } from './metabase.types.js';
+ */
+
+import { sortBy } from '../../../../lib/utils.js';
+import { toArray } from '../../../../utils/environment-utils.js';
+
+/**
+ * @param {any} response
+ * @returns {MetabaseInfo}
+ */
+export function transformMetabaseInfo(response) {
+  return {
+    id: response.resourceId,
+    addonId: response.addonId,
+    name: response.name,
+    ownerId: response.ownerId,
+    plan: response.plan,
+    version: response.version,
+    javaVersion: response.javaVersion,
+    accessUrl: response.accessUrl,
+    availableVersions: response.availableVersions,
+    resources: response.resources,
+    environment: sortBy(toArray(response.envVars), 'name'),
+  };
+}

--- a/src/clients/cc-api/commands/metabase/metabase.types.d.ts
+++ b/src/clients/cc-api/commands/metabase/metabase.types.d.ts
@@ -1,0 +1,18 @@
+import type { EnvironmentVariable } from '../../../../utils/environment.types.js';
+
+export interface MetabaseInfo {
+  id: string;
+  addonId: string;
+  name: string;
+  ownerId: string;
+  plan: string;
+  version: string;
+  javaVersion: string;
+  accessUrl: string;
+  availableVersions: Array<string>;
+  resources: {
+    entrypoint: string;
+    pgsqlId: string | null;
+  };
+  environment: Array<EnvironmentVariable>;
+}

--- a/src/clients/cc-api/commands/metabase/reboot-metabase-command.js
+++ b/src/clients/cc-api/commands/metabase/reboot-metabase-command.js
@@ -1,0 +1,32 @@
+/**
+ * @import { RebootMetabaseCommandInput } from './reboot-metabase-command.types.js';
+ */
+import { post } from '../../../../lib/request/request-params-builder.js';
+import { safeUrl } from '../../../../lib/utils.js';
+import { CcApiSimpleCommand } from '../../lib/cc-api-command.js';
+
+/**
+ *
+ * @extends {CcApiSimpleCommand<RebootMetabaseCommandInput, void>}
+ * @endpoint [POST] /v4/addon-providers/addon-metabase/addons/:XXX/reboot
+ * @group Metabase
+ * @version 4
+ */
+export class RebootMetabaseCommand extends CcApiSimpleCommand {
+  /** @type {CcApiSimpleCommand<RebootMetabaseCommandInput, void>['toRequestParams']} */
+  toRequestParams(params) {
+    return post(safeUrl`/v4/addon-providers/addon-metabase/addons/${params.addonId}/reboot`);
+  }
+
+  /** @type {CcApiSimpleCommand<?, ?>['getIdsToResolve']} */
+  getIdsToResolve() {
+    return {
+      addonId: 'REAL_ADDON_ID',
+    };
+  }
+
+  /** @type {CcApiSimpleCommand<RebootMetabaseCommandInput, void>['transformCommandOutput']} */
+  transformCommandOutput() {
+    return null;
+  }
+}

--- a/src/clients/cc-api/commands/metabase/reboot-metabase-command.types.d.ts
+++ b/src/clients/cc-api/commands/metabase/reboot-metabase-command.types.d.ts
@@ -1,0 +1,3 @@
+export type RebootMetabaseCommandInput = {
+  addonId: string;
+};

--- a/src/clients/cc-api/commands/metabase/rebuild-metabase-command.js
+++ b/src/clients/cc-api/commands/metabase/rebuild-metabase-command.js
@@ -1,0 +1,32 @@
+/**
+ * @import { RebuildMetabaseCommandInput } from './rebuild-metabase-command.types.js';
+ */
+import { post } from '../../../../lib/request/request-params-builder.js';
+import { safeUrl } from '../../../../lib/utils.js';
+import { CcApiSimpleCommand } from '../../lib/cc-api-command.js';
+
+/**
+ *
+ * @extends {CcApiSimpleCommand<RebuildMetabaseCommandInput, void>}
+ * @endpoint [POST] /v4/addon-providers/addon-metabase/addons/:XXX/rebuild
+ * @group Metabase
+ * @version 4
+ */
+export class RebuildMetabaseCommand extends CcApiSimpleCommand {
+  /** @type {CcApiSimpleCommand<RebuildMetabaseCommandInput, void>['toRequestParams']} */
+  toRequestParams(params) {
+    return post(safeUrl`/v4/addon-providers/addon-metabase/addons/${params.addonId}/rebuild`);
+  }
+
+  /** @type {CcApiSimpleCommand<?, ?>['getIdsToResolve']} */
+  getIdsToResolve() {
+    return {
+      addonId: 'REAL_ADDON_ID',
+    };
+  }
+
+  /** @type {CcApiSimpleCommand<RebuildMetabaseCommandInput, void>['transformCommandOutput']} */
+  transformCommandOutput() {
+    return null;
+  }
+}

--- a/src/clients/cc-api/commands/metabase/rebuild-metabase-command.types.d.ts
+++ b/src/clients/cc-api/commands/metabase/rebuild-metabase-command.types.d.ts
@@ -1,0 +1,3 @@
+export type RebuildMetabaseCommandInput = {
+  addonId: string;
+};

--- a/src/clients/cc-api/commands/metabase/update-metabase-version-command.js
+++ b/src/clients/cc-api/commands/metabase/update-metabase-version-command.js
@@ -1,0 +1,35 @@
+/**
+ * @import { UpdateMetabaseVersionCommandInput, UpdateMetabaseVersionCommandOutput } from './update-metabase-version-command.types.js';
+ */
+import { postJson } from '../../../../lib/request/request-params-builder.js';
+import { safeUrl } from '../../../../lib/utils.js';
+import { CcApiSimpleCommand } from '../../lib/cc-api-command.js';
+import { transformMetabaseInfo } from './metabase-transform.js';
+
+/**
+ *
+ * @extends {CcApiSimpleCommand<UpdateMetabaseVersionCommandInput, UpdateMetabaseVersionCommandOutput>}
+ * @endpoint [POST] /v4/addon-providers/addon-metabase/addons/:XXX/version/update
+ * @group Metabase
+ * @version 4
+ */
+export class UpdateMetabaseVersionCommand extends CcApiSimpleCommand {
+  /** @type {CcApiSimpleCommand<UpdateMetabaseVersionCommandInput, UpdateMetabaseVersionCommandOutput>['toRequestParams']} */
+  toRequestParams(params) {
+    return postJson(safeUrl`/v4/addon-providers/addon-metabase/addons/${params.addonId}/version/update`, {
+      targetVersion: params.targetVersion,
+    });
+  }
+
+  /** @type {CcApiSimpleCommand<?, ?>['getIdsToResolve']} */
+  getIdsToResolve() {
+    return {
+      addonId: 'REAL_ADDON_ID',
+    };
+  }
+
+  /** @type {CcApiSimpleCommand<UpdateMetabaseVersionCommandInput, UpdateMetabaseVersionCommandOutput>['transformCommandOutput']} */
+  transformCommandOutput(response) {
+    return transformMetabaseInfo(response);
+  }
+}

--- a/src/clients/cc-api/commands/metabase/update-metabase-version-command.types.d.ts
+++ b/src/clients/cc-api/commands/metabase/update-metabase-version-command.types.d.ts
@@ -1,0 +1,8 @@
+import type { MetabaseInfo } from './metabase.types.js';
+
+export type UpdateMetabaseVersionCommandInput = {
+  addonId: string;
+  targetVersion: string;
+};
+
+export type UpdateMetabaseVersionCommandOutput = MetabaseInfo;

--- a/src/clients/cc-api/commands/otoroshi/check-otoroshi-version-command.js
+++ b/src/clients/cc-api/commands/otoroshi/check-otoroshi-version-command.js
@@ -1,0 +1,37 @@
+/**
+ * @import { CheckOtoroshiVersionCommandInput, CheckOtoroshiVersionCommandOutput } from './check-otoroshi-version-command.types.js';
+ */
+import { get } from '../../../../lib/request/request-params-builder.js';
+import { safeUrl } from '../../../../lib/utils.js';
+import { CcApiSimpleCommand } from '../../lib/cc-api-command.js';
+
+/**
+ *
+ * @extends {CcApiSimpleCommand<CheckOtoroshiVersionCommandInput, CheckOtoroshiVersionCommandOutput>}
+ * @endpoint [GET] /v4/addon-providers/addon-otoroshi/addons/:XXX/version/check
+ * @group Otoroshi
+ * @version 4
+ */
+export class CheckOtoroshiVersionCommand extends CcApiSimpleCommand {
+  /** @type {CcApiSimpleCommand<CheckOtoroshiVersionCommandInput, CheckOtoroshiVersionCommandOutput>['toRequestParams']} */
+  toRequestParams(params) {
+    return get(safeUrl`/v4/addon-providers/addon-otoroshi/addons/${params.addonId}/version/check`);
+  }
+
+  /** @type {CcApiSimpleCommand<?, ?>['getIdsToResolve']} */
+  getIdsToResolve() {
+    return {
+      addonId: 'REAL_ADDON_ID',
+    };
+  }
+
+  /** @type {CcApiSimpleCommand<CheckOtoroshiVersionCommandInput, CheckOtoroshiVersionCommandOutput>['transformCommandOutput']} */
+  transformCommandOutput(response) {
+    return {
+      installed: response.installed,
+      available: response.available,
+      needUpdate: response.needUpdate,
+      latest: response.latest,
+    };
+  }
+}

--- a/src/clients/cc-api/commands/otoroshi/check-otoroshi-version-command.types.d.ts
+++ b/src/clients/cc-api/commands/otoroshi/check-otoroshi-version-command.types.d.ts
@@ -1,0 +1,10 @@
+export interface CheckOtoroshiVersionCommandInput {
+  addonId: string;
+}
+
+export type CheckOtoroshiVersionCommandOutput = {
+  installed: string;
+  available: Array<string>;
+  latest: string;
+  needUpdate: boolean;
+};

--- a/src/clients/cc-api/commands/otoroshi/create-otoroshi-network-group-command.js
+++ b/src/clients/cc-api/commands/otoroshi/create-otoroshi-network-group-command.js
@@ -1,0 +1,33 @@
+/**
+ * @import { CreateOtoroshiNetworkGroupCommandInput, CreateOtoroshiNetworkGroupCommandOutput } from './create-otoroshi-network-group-command.types.js';
+ */
+import { post } from '../../../../lib/request/request-params-builder.js';
+import { safeUrl } from '../../../../lib/utils.js';
+import { CcApiSimpleCommand } from '../../lib/cc-api-command.js';
+import { transformOtoroshiInfo } from './otoroshi-transform.js';
+
+/**
+ *
+ * @extends {CcApiSimpleCommand<CreateOtoroshiNetworkGroupCommandInput, CreateOtoroshiNetworkGroupCommandOutput>}
+ * @endpoint [POST] /v4/addon-providers/addon-otoroshi/addons/:XXX/networkgroup
+ * @group Otoroshi
+ * @version 4
+ */
+export class CreateOtoroshiNetworkGroupCommand extends CcApiSimpleCommand {
+  /** @type {CcApiSimpleCommand<CreateOtoroshiNetworkGroupCommandInput, CreateOtoroshiNetworkGroupCommandOutput>['toRequestParams']} */
+  toRequestParams(params) {
+    return post(safeUrl`/v4/addon-providers/addon-otoroshi/addons/${params.addonId}/networkgroup`);
+  }
+
+  /** @type {CcApiSimpleCommand<?, ?>['getIdsToResolve']} */
+  getIdsToResolve() {
+    return {
+      addonId: 'REAL_ADDON_ID',
+    };
+  }
+
+  /** @type {CcApiSimpleCommand<CreateOtoroshiNetworkGroupCommandInput, CreateOtoroshiNetworkGroupCommandOutput>['transformCommandOutput']} */
+  transformCommandOutput(response) {
+    return transformOtoroshiInfo(response);
+  }
+}

--- a/src/clients/cc-api/commands/otoroshi/create-otoroshi-network-group-command.types.d.ts
+++ b/src/clients/cc-api/commands/otoroshi/create-otoroshi-network-group-command.types.d.ts
@@ -1,0 +1,7 @@
+import type { OtoroshiInfo } from './otoroshi.types.js';
+
+export interface CreateOtoroshiNetworkGroupCommandInput {
+  addonId: string;
+}
+
+export type CreateOtoroshiNetworkGroupCommandOutput = OtoroshiInfo;

--- a/src/clients/cc-api/commands/otoroshi/delete-otoroshi-network-group-command.js
+++ b/src/clients/cc-api/commands/otoroshi/delete-otoroshi-network-group-command.js
@@ -1,0 +1,32 @@
+/**
+ * @import { DeleteOtoroshiNetworkGroupCommandInput } from './delete-otoroshi-network-group-command.types.js';
+ */
+import { delete_ } from '../../../../lib/request/request-params-builder.js';
+import { safeUrl } from '../../../../lib/utils.js';
+import { CcApiSimpleCommand } from '../../lib/cc-api-command.js';
+
+/**
+ *
+ * @extends {CcApiSimpleCommand<DeleteOtoroshiNetworkGroupCommandInput, void>}
+ * @endpoint [DELETE] /v4/addon-providers/addon-otoroshi/addons/:XXX/networkgroup
+ * @group Otoroshi
+ * @version 4
+ */
+export class DeleteOtoroshiNetworkGroupCommand extends CcApiSimpleCommand {
+  /** @type {CcApiSimpleCommand<DeleteOtoroshiNetworkGroupCommandInput, void>['toRequestParams']} */
+  toRequestParams(params) {
+    return delete_(safeUrl`/v4/addon-providers/addon-otoroshi/addons/${params.addonId}/networkgroup`);
+  }
+
+  /** @type {CcApiSimpleCommand<?, ?>['getIdsToResolve']} */
+  getIdsToResolve() {
+    return {
+      addonId: 'REAL_ADDON_ID',
+    };
+  }
+
+  /** @type {CcApiSimpleCommand<DeleteOtoroshiNetworkGroupCommandInput, void>['transformCommandOutput']} */
+  transformCommandOutput() {
+    return null;
+  }
+}

--- a/src/clients/cc-api/commands/otoroshi/delete-otoroshi-network-group-command.types.d.ts
+++ b/src/clients/cc-api/commands/otoroshi/delete-otoroshi-network-group-command.types.d.ts
@@ -1,0 +1,3 @@
+export interface DeleteOtoroshiNetworkGroupCommandInput {
+  addonId: string;
+}

--- a/src/clients/cc-api/commands/otoroshi/get-otoroshi-config-command.js
+++ b/src/clients/cc-api/commands/otoroshi/get-otoroshi-config-command.js
@@ -1,0 +1,39 @@
+/**
+ * @import { GetOtoroshiConfigCommandInput, GetOtoroshiConfigCommandOutput } from './get-otoroshi-config-command.types.js';
+ */
+import { HeadersBuilder } from '../../../../lib/request/headers-builder.js';
+import { safeUrl } from '../../../../lib/utils.js';
+import { CcApiSimpleCommand } from '../../lib/cc-api-command.js';
+
+/**
+ *
+ * @extends {CcApiSimpleCommand<GetOtoroshiConfigCommandInput, GetOtoroshiConfigCommandOutput>}
+ * @endpoint [GET] /v4/addon-providers/addon-otoroshi/addons/:XXX/config.yaml
+ * @group Otoroshi
+ * @version 4
+ */
+export class GetOtoroshiConfigCommand extends CcApiSimpleCommand {
+  /** @type {CcApiSimpleCommand<GetOtoroshiConfigCommandInput, GetOtoroshiConfigCommandOutput>['toRequestParams']} */
+  toRequestParams(params) {
+    return {
+      method: 'GET',
+      url: safeUrl`/v4/addon-providers/addon-otoroshi/addons/${params.addonId}/config.yaml`,
+      headers: new HeadersBuilder().accept('application/yaml').build(),
+    };
+  }
+
+  /** @type {CcApiSimpleCommand<?, ?>['getIdsToResolve']} */
+  getIdsToResolve() {
+    return {
+      addonId: 'REAL_ADDON_ID',
+    };
+  }
+
+  /** @type {CcApiSimpleCommand<GetOtoroshiConfigCommandInput, GetOtoroshiConfigCommandOutput>['transformCommandOutput']} */
+  async transformCommandOutput(response) {
+    if (typeof response === 'string') {
+      return response;
+    }
+    return response.text();
+  }
+}

--- a/src/clients/cc-api/commands/otoroshi/get-otoroshi-config-command.types.d.ts
+++ b/src/clients/cc-api/commands/otoroshi/get-otoroshi-config-command.types.d.ts
@@ -1,0 +1,5 @@
+export interface GetOtoroshiConfigCommandInput {
+  addonId: string;
+}
+
+export type GetOtoroshiConfigCommandOutput = string;

--- a/src/clients/cc-api/commands/otoroshi/get-otoroshi-info-command.js
+++ b/src/clients/cc-api/commands/otoroshi/get-otoroshi-info-command.js
@@ -1,0 +1,38 @@
+/**
+ * @import { GetOtoroshiInfoCommandInput, GetOtoroshiInfoCommandOutput } from './get-otoroshi-info-command.types.js';
+ */
+import { get } from '../../../../lib/request/request-params-builder.js';
+import { safeUrl } from '../../../../lib/utils.js';
+import { CcApiSimpleCommand } from '../../lib/cc-api-command.js';
+import { transformOtoroshiInfo } from './otoroshi-transform.js';
+
+/**
+ *
+ * @extends {CcApiSimpleCommand<GetOtoroshiInfoCommandInput, GetOtoroshiInfoCommandOutput>}
+ * @endpoint [GET] /v4/addon-providers/addon-otoroshi/addons/:XXX
+ * @group Otoroshi
+ * @version 4
+ */
+export class GetOtoroshiInfoCommand extends CcApiSimpleCommand {
+  /** @type {CcApiSimpleCommand<GetOtoroshiInfoCommandInput, GetOtoroshiInfoCommandOutput>['toRequestParams']} */
+  toRequestParams(params) {
+    return get(safeUrl`/v4/addon-providers/addon-otoroshi/addons/${params.addonId}`);
+  }
+
+  /** @type {CcApiSimpleCommand<?, ?>['getIdsToResolve']} */
+  getIdsToResolve() {
+    return {
+      addonId: 'REAL_ADDON_ID',
+    };
+  }
+
+  /** @type {CcApiSimpleCommand<?, ?>['getEmptyResponsePolicy']} */
+  getEmptyResponsePolicy(status) {
+    return { isEmpty: status === 404 };
+  }
+
+  /** @type {CcApiSimpleCommand<GetOtoroshiInfoCommandInput, GetOtoroshiInfoCommandOutput>['transformCommandOutput']} */
+  transformCommandOutput(response) {
+    return transformOtoroshiInfo(response);
+  }
+}

--- a/src/clients/cc-api/commands/otoroshi/get-otoroshi-info-command.types.d.ts
+++ b/src/clients/cc-api/commands/otoroshi/get-otoroshi-info-command.types.d.ts
@@ -1,0 +1,7 @@
+import type { OtoroshiInfo } from './otoroshi.types.js';
+
+export interface GetOtoroshiInfoCommandInput {
+  addonId: string;
+}
+
+export type GetOtoroshiInfoCommandOutput = OtoroshiInfo;

--- a/src/clients/cc-api/commands/otoroshi/otoroshi-transform.js
+++ b/src/clients/cc-api/commands/otoroshi/otoroshi-transform.js
@@ -1,0 +1,29 @@
+/**
+ * @import { OtoroshiInfo } from './otoroshi.types.js';
+ */
+
+import { sortBy } from '../../../../lib/utils.js';
+import { toArray } from '../../../../utils/environment-utils.js';
+
+/**
+ * @param {any} response
+ * @returns {OtoroshiInfo}
+ */
+export function transformOtoroshiInfo(response) {
+  return {
+    id: response.resourceId,
+    addonId: response.addonId,
+    name: response.name,
+    ownerId: response.ownerId,
+    plan: response.plan,
+    version: response.version,
+    javaVersion: response.javaVersion,
+    accessUrl: response.accessUrl,
+    availableVersions: response.availableVersions,
+    resources: response.resources,
+    features: response.features,
+    api: response.api,
+    initialCredentials: response.initialCredentials,
+    environment: sortBy(toArray(response.envVars), 'name'),
+  };
+}

--- a/src/clients/cc-api/commands/otoroshi/otoroshi.types.d.ts
+++ b/src/clients/cc-api/commands/otoroshi/otoroshi.types.d.ts
@@ -1,0 +1,33 @@
+import type { EnvironmentVariable } from '../../../../utils/environment.types.js';
+
+export interface OtoroshiInfo {
+  id: string;
+  addonId: string;
+  name: string;
+  ownerId: string;
+  plan: string;
+  version: string;
+  javaVersion: string;
+  accessUrl: string;
+  availableVersions: Array<string>;
+  resources: {
+    entrypoint: string;
+    redisId: string;
+    pulsarId: string | null;
+    elasticId: string | null;
+  };
+  features: {
+    networkGroup: { id: string } | null;
+  };
+  api: {
+    url: string;
+    user: string;
+    secret: string;
+    openapi: string;
+  };
+  initialCredentials: {
+    user: string;
+    password: string;
+  };
+  environment: Array<EnvironmentVariable>;
+}

--- a/src/clients/cc-api/commands/otoroshi/reboot-otoroshi-command.js
+++ b/src/clients/cc-api/commands/otoroshi/reboot-otoroshi-command.js
@@ -1,0 +1,32 @@
+/**
+ * @import { RebootOtoroshiCommandInput } from './reboot-otoroshi-command.types.js';
+ */
+import { post } from '../../../../lib/request/request-params-builder.js';
+import { safeUrl } from '../../../../lib/utils.js';
+import { CcApiSimpleCommand } from '../../lib/cc-api-command.js';
+
+/**
+ *
+ * @extends {CcApiSimpleCommand<RebootOtoroshiCommandInput, void>}
+ * @endpoint [POST] /v4/addon-providers/addon-otoroshi/addons/:XXX/reboot
+ * @group Otoroshi
+ * @version 4
+ */
+export class RebootOtoroshiCommand extends CcApiSimpleCommand {
+  /** @type {CcApiSimpleCommand<RebootOtoroshiCommandInput, void>['toRequestParams']} */
+  toRequestParams(params) {
+    return post(safeUrl`/v4/addon-providers/addon-otoroshi/addons/${params.addonId}/reboot`);
+  }
+
+  /** @type {CcApiSimpleCommand<?, ?>['getIdsToResolve']} */
+  getIdsToResolve() {
+    return {
+      addonId: 'REAL_ADDON_ID',
+    };
+  }
+
+  /** @type {CcApiSimpleCommand<RebootOtoroshiCommandInput, void>['transformCommandOutput']} */
+  transformCommandOutput() {
+    return null;
+  }
+}

--- a/src/clients/cc-api/commands/otoroshi/reboot-otoroshi-command.types.d.ts
+++ b/src/clients/cc-api/commands/otoroshi/reboot-otoroshi-command.types.d.ts
@@ -1,0 +1,3 @@
+export interface RebootOtoroshiCommandInput {
+  addonId: string;
+}

--- a/src/clients/cc-api/commands/otoroshi/rebuild-otoroshi-command.js
+++ b/src/clients/cc-api/commands/otoroshi/rebuild-otoroshi-command.js
@@ -1,0 +1,32 @@
+/**
+ * @import { RebuildOtoroshiCommandInput } from './rebuild-otoroshi-command.types.js';
+ */
+import { post } from '../../../../lib/request/request-params-builder.js';
+import { safeUrl } from '../../../../lib/utils.js';
+import { CcApiSimpleCommand } from '../../lib/cc-api-command.js';
+
+/**
+ *
+ * @extends {CcApiSimpleCommand<RebuildOtoroshiCommandInput, void>}
+ * @endpoint [POST] /v4/addon-providers/addon-otoroshi/addons/:XXX/rebuild
+ * @group Otoroshi
+ * @version 4
+ */
+export class RebuildOtoroshiCommand extends CcApiSimpleCommand {
+  /** @type {CcApiSimpleCommand<RebuildOtoroshiCommandInput, void>['toRequestParams']} */
+  toRequestParams(params) {
+    return post(safeUrl`/v4/addon-providers/addon-otoroshi/addons/${params.addonId}/rebuild`);
+  }
+
+  /** @type {CcApiSimpleCommand<?, ?>['getIdsToResolve']} */
+  getIdsToResolve() {
+    return {
+      addonId: 'REAL_ADDON_ID',
+    };
+  }
+
+  /** @type {CcApiSimpleCommand<RebuildOtoroshiCommandInput, void>['transformCommandOutput']} */
+  transformCommandOutput() {
+    return null;
+  }
+}

--- a/src/clients/cc-api/commands/otoroshi/rebuild-otoroshi-command.types.d.ts
+++ b/src/clients/cc-api/commands/otoroshi/rebuild-otoroshi-command.types.d.ts
@@ -1,0 +1,3 @@
+export interface RebuildOtoroshiCommandInput {
+  addonId: string;
+}

--- a/src/clients/cc-api/commands/otoroshi/update-otoroshi-version-command.js
+++ b/src/clients/cc-api/commands/otoroshi/update-otoroshi-version-command.js
@@ -1,0 +1,35 @@
+/**
+ * @import { UpdateOtoroshiVersionCommandInput, UpdateOtoroshiVersionCommandOutput } from './update-otoroshi-version-command.types.js';
+ */
+import { postJson } from '../../../../lib/request/request-params-builder.js';
+import { safeUrl } from '../../../../lib/utils.js';
+import { CcApiSimpleCommand } from '../../lib/cc-api-command.js';
+import { transformOtoroshiInfo } from './otoroshi-transform.js';
+
+/**
+ *
+ * @extends {CcApiSimpleCommand<UpdateOtoroshiVersionCommandInput, UpdateOtoroshiVersionCommandOutput>}
+ * @endpoint [POST] /v4/addon-providers/addon-otoroshi/addons/:XXX/version/update
+ * @group Otoroshi
+ * @version 4
+ */
+export class UpdateOtoroshiVersionCommand extends CcApiSimpleCommand {
+  /** @type {CcApiSimpleCommand<UpdateOtoroshiVersionCommandInput, UpdateOtoroshiVersionCommandOutput>['toRequestParams']} */
+  toRequestParams(params) {
+    return postJson(safeUrl`/v4/addon-providers/addon-otoroshi/addons/${params.addonId}/version/update`, {
+      targetVersion: params.targetVersion,
+    });
+  }
+
+  /** @type {CcApiSimpleCommand<?, ?>['getIdsToResolve']} */
+  getIdsToResolve() {
+    return {
+      addonId: 'REAL_ADDON_ID',
+    };
+  }
+
+  /** @type {CcApiSimpleCommand<UpdateOtoroshiVersionCommandInput, UpdateOtoroshiVersionCommandOutput>['transformCommandOutput']} */
+  transformCommandOutput(response) {
+    return transformOtoroshiInfo(response);
+  }
+}

--- a/src/clients/cc-api/commands/otoroshi/update-otoroshi-version-command.types.d.ts
+++ b/src/clients/cc-api/commands/otoroshi/update-otoroshi-version-command.types.d.ts
@@ -1,0 +1,8 @@
+import type { OtoroshiInfo } from './otoroshi.types.js';
+
+export interface UpdateOtoroshiVersionCommandInput {
+  addonId: string;
+  targetVersion: string;
+}
+
+export type UpdateOtoroshiVersionCommandOutput = OtoroshiInfo;

--- a/test/e2e/clients/cc-api/commands/keycloak-commands.spec.js
+++ b/test/e2e/clients/cc-api/commands/keycloak-commands.spec.js
@@ -1,0 +1,132 @@
+import { expect } from 'chai';
+import { CheckKeycloakVersionCommand } from '../../../../../src/clients/cc-api/commands/keycloak/check-keycloak-version-command.js';
+import { CreateKeycloakNetworkGroupCommand } from '../../../../../src/clients/cc-api/commands/keycloak/create-keycloak-network-group-command.js';
+import { DeleteKeycloakNetworkGroupCommand } from '../../../../../src/clients/cc-api/commands/keycloak/delete-keycloak-network-group-command.js';
+import { GetKeycloakInfoCommand } from '../../../../../src/clients/cc-api/commands/keycloak/get-keycloak-info-command.js';
+import { RebootKeycloakCommand } from '../../../../../src/clients/cc-api/commands/keycloak/reboot-keycloak-command.js';
+import { RebuildKeycloakCommand } from '../../../../../src/clients/cc-api/commands/keycloak/rebuild-keycloak-command.js';
+import { UpdateKeycloakVersionCommand } from '../../../../../src/clients/cc-api/commands/keycloak/update-keycloak-version-command.js';
+import { e2eSupport } from '../e2e-support.js';
+
+describe('keycloak commands', function () {
+  const support = e2eSupport();
+
+  before(async () => {
+    await support.prepare();
+  });
+
+  afterEach(async () => {
+    await support.deleteAddons();
+  });
+
+  after(async () => {
+    await support.cleanup();
+  });
+
+  it('should get keycloak info', async () => {
+    const addon = await support.createTestAddon({
+      name: 'test-keycloak-addon',
+      providerId: 'keycloak',
+      planId: 'plan_3819e4b3-cc6d-4847-9f02-0db93212956c',
+    });
+    const response = await support.client.send(new GetKeycloakInfoCommand({ addonId: addon.id }));
+
+    expect(response.id).to.equal(addon.realId);
+    expect(response.addonId).to.equal(addon.id);
+    expect(response.name).to.equal(addon.name);
+    expect(response.ownerId).to.equal(support.organisationId);
+    expect(response.plan).to.be.a('string');
+    expect(response.version).to.be.a('string');
+    expect(response.javaVersion).to.be.a('string');
+    expect(response.accessUrl).to.be.a('string');
+    expect(response.availableVersions).to.be.an('array');
+    expect(response.resources.entrypoint).to.be.a('string');
+    expect(response.resources.fsbucketId).to.be.a('string');
+    expect(response.resources.pgsqlId).to.be.a('string');
+    expect(response.features).to.be.an('object').that.is.not.null;
+    expect(response.initialCredentials.user).to.be.a('string');
+    expect(response.initialCredentials.password).to.be.a('string');
+    expect(response.environment).to.be.an('array');
+  });
+
+  it('should reboot keycloak', async () => {
+    const addon = await support.createTestAddon({
+      name: 'test-keycloak-addon',
+      providerId: 'keycloak',
+      planId: 'plan_3819e4b3-cc6d-4847-9f02-0db93212956c',
+    });
+    const response = await support.client.send(new RebootKeycloakCommand({ addonId: addon.id }));
+
+    expect(response).to.be.null;
+  });
+
+  it('should rebuild keycloak', async () => {
+    const addon = await support.createTestAddon({
+      name: 'test-keycloak-addon',
+      providerId: 'keycloak',
+      planId: 'plan_3819e4b3-cc6d-4847-9f02-0db93212956c',
+    });
+    const response = await support.client.send(new RebuildKeycloakCommand({ addonId: addon.id }));
+
+    expect(response).to.be.null;
+  });
+
+  it('should check keycloak version', async () => {
+    const addon = await support.createTestAddon({
+      name: 'test-keycloak-addon',
+      providerId: 'keycloak',
+      planId: 'plan_3819e4b3-cc6d-4847-9f02-0db93212956c',
+    });
+    const response = await support.client.send(new CheckKeycloakVersionCommand({ addonId: addon.id }));
+
+    expect(response.installed).to.be.a('string');
+    expect(response.latest).to.be.a('string');
+    expect(response.available).to.be.an('array').that.includes(response.latest);
+    expect(response.needUpdate).to.be.a('boolean');
+  });
+
+  it('should update keycloak version', async () => {
+    const addon = await support.createTestAddon({
+      name: 'test-keycloak-addon',
+      providerId: 'keycloak',
+      planId: 'plan_3819e4b3-cc6d-4847-9f02-0db93212956c',
+    });
+    const info = await support.client.send(new GetKeycloakInfoCommand({ addonId: addon.id }));
+
+    // update to the current version to be a no-op
+    const response = await support.client.send(
+      new UpdateKeycloakVersionCommand({ addonId: addon.id, targetVersion: info.version }),
+    );
+
+    expect(response.id).to.equal(addon.realId);
+    expect(response.version).to.be.a('string');
+    expect(response.environment).to.be.an('array');
+  });
+
+  it('should create keycloak network group', async () => {
+    const addon = await support.createTestAddon({
+      name: 'test-keycloak-addon',
+      providerId: 'keycloak',
+      planId: 'plan_3819e4b3-cc6d-4847-9f02-0db93212956c',
+    });
+    const response = await support.client.send(new CreateKeycloakNetworkGroupCommand({ addonId: addon.id }));
+
+    expect(response.id).to.equal(addon.realId);
+    expect(response.features.networkGroup).to.not.be.null;
+    expect(response.features.networkGroup.id).to.be.a('string');
+  });
+
+  it('should delete keycloak network group', async () => {
+    const addon = await support.createTestAddon({
+      name: 'test-keycloak-addon',
+      providerId: 'keycloak',
+      planId: 'plan_3819e4b3-cc6d-4847-9f02-0db93212956c',
+    });
+    // Create a network group first so we can delete it
+    await support.client.send(new CreateKeycloakNetworkGroupCommand({ addonId: addon.id }));
+
+    const response = await support.client.send(new DeleteKeycloakNetworkGroupCommand({ addonId: addon.id }));
+
+    expect(response).to.be.null;
+  });
+});

--- a/test/e2e/clients/cc-api/commands/matomo-commands.spec.js
+++ b/test/e2e/clients/cc-api/commands/matomo-commands.spec.js
@@ -1,22 +1,22 @@
 import { expect } from 'chai';
 import { GetMatomoInfoCommand } from '../../../../../src/clients/cc-api/commands/matomo/get-matomo-info-command.js';
+import { RebootMatomoCommand } from '../../../../../src/clients/cc-api/commands/matomo/reboot-matomo-command.js';
+import { RebuildMatomoCommand } from '../../../../../src/clients/cc-api/commands/matomo/rebuild-matomo-command.js';
 import { e2eSupport } from '../e2e-support.js';
 
-// cannot be automatised because addon deletion just after creation is not supported by the platform
-// todo: find a way to wait for addon to be ready for deletion
-describe.skip('matomo commands', function () {
+describe('matomo commands', function () {
   const support = e2eSupport();
 
   before(async () => {
     await support.prepare();
   });
 
-  after(async () => {
-    await support.cleanup();
-  });
-
   afterEach(async () => {
     await support.deleteAddons();
+  });
+
+  after(async () => {
+    await support.cleanup();
   });
 
   it('should get matomo info', async () => {
@@ -25,7 +25,6 @@ describe.skip('matomo commands', function () {
       providerId: 'addon-matomo',
       planId: 'plan_87283ba6-617c-420d-8e37-3350a2fcdd66',
     });
-
     const response = await support.client.send(new GetMatomoInfoCommand({ addonId: addon.id }));
 
     expect(response.id).to.equal(addon.realId);
@@ -40,6 +39,29 @@ describe.skip('matomo commands', function () {
     expect(response.resources.entrypoint).to.be.a('string');
     expect(response.resources.mysqlId).to.be.a('string');
     expect(response.resources.redisId).to.be.a('string');
+    expect(response.resources.kvId == null || typeof response.resources.kvId === 'string').to.be.true;
     expect(response.environment).to.be.a('array');
+  });
+
+  it('should reboot matomo', async () => {
+    const addon = await support.createTestAddon({
+      name: 'test-matomo-addon',
+      providerId: 'addon-matomo',
+      planId: 'plan_87283ba6-617c-420d-8e37-3350a2fcdd66',
+    });
+    const response = await support.client.send(new RebootMatomoCommand({ addonId: addon.id }));
+
+    expect(response).to.be.null;
+  });
+
+  it('should rebuild matomo', async () => {
+    const addon = await support.createTestAddon({
+      name: 'test-matomo-addon',
+      providerId: 'addon-matomo',
+      planId: 'plan_87283ba6-617c-420d-8e37-3350a2fcdd66',
+    });
+    const response = await support.client.send(new RebuildMatomoCommand({ addonId: addon.id }));
+
+    expect(response).to.be.null;
   });
 });

--- a/test/e2e/clients/cc-api/commands/metabase-commands.spec.js
+++ b/test/e2e/clients/cc-api/commands/metabase-commands.spec.js
@@ -1,0 +1,98 @@
+import { expect } from 'chai';
+import { CheckMetabaseVersionCommand } from '../../../../../src/clients/cc-api/commands/metabase/check-metabase-version-command.js';
+import { GetMetabaseInfoCommand } from '../../../../../src/clients/cc-api/commands/metabase/get-metabase-info-command.js';
+import { RebootMetabaseCommand } from '../../../../../src/clients/cc-api/commands/metabase/reboot-metabase-command.js';
+import { RebuildMetabaseCommand } from '../../../../../src/clients/cc-api/commands/metabase/rebuild-metabase-command.js';
+import { UpdateMetabaseVersionCommand } from '../../../../../src/clients/cc-api/commands/metabase/update-metabase-version-command.js';
+import { e2eSupport } from '../e2e-support.js';
+
+describe('metabase commands', function () {
+  const support = e2eSupport();
+
+  before(async () => {
+    await support.prepare();
+  });
+
+  afterEach(async () => {
+    await support.deleteAddons();
+  });
+
+  after(async () => {
+    await support.cleanup();
+  });
+
+  it('should get metabase info', async () => {
+    const addon = await support.createTestAddon({
+      name: 'test-metabase-addon',
+      providerId: 'metabase',
+      planId: 'plan_2925d534-7155-4521-8052-d068d7ce8915',
+    });
+    const response = await support.client.send(new GetMetabaseInfoCommand({ addonId: addon.id }));
+
+    expect(response.id).to.equal(addon.realId);
+    expect(response.addonId).to.equal(addon.id);
+    expect(response.name).to.equal(addon.name);
+    expect(response.ownerId).to.equal(support.organisationId);
+    expect(response.plan).to.be.a('string');
+    expect(response.version).to.be.a('string');
+    expect(response.javaVersion).to.be.a('string');
+    expect(response.accessUrl).to.be.a('string');
+    expect(response.availableVersions).to.be.an('array');
+    expect(response.resources.entrypoint).to.be.a('string');
+    expect(response.resources.pgsqlId).to.be.a('string');
+    expect(response.environment).to.be.an('array');
+  });
+
+  it('should reboot metabase', async () => {
+    const addon = await support.createTestAddon({
+      name: 'test-metabase-addon',
+      providerId: 'metabase',
+      planId: 'plan_2925d534-7155-4521-8052-d068d7ce8915',
+    });
+    const response = await support.client.send(new RebootMetabaseCommand({ addonId: addon.id }));
+
+    expect(response).to.be.null;
+  });
+
+  it('should rebuild metabase', async () => {
+    const addon = await support.createTestAddon({
+      name: 'test-metabase-addon',
+      providerId: 'metabase',
+      planId: 'plan_2925d534-7155-4521-8052-d068d7ce8915',
+    });
+    const response = await support.client.send(new RebuildMetabaseCommand({ addonId: addon.id }));
+
+    expect(response).to.be.null;
+  });
+
+  it('should check metabase version', async () => {
+    const addon = await support.createTestAddon({
+      name: 'test-metabase-addon',
+      providerId: 'metabase',
+      planId: 'plan_2925d534-7155-4521-8052-d068d7ce8915',
+    });
+    const response = await support.client.send(new CheckMetabaseVersionCommand({ addonId: addon.id }));
+
+    expect(response.installed).to.be.a('string');
+    expect(response.latest).to.be.a('string');
+    expect(response.available).to.be.an('array').that.includes(response.latest);
+    expect(response.needUpdate).to.be.a('boolean');
+  });
+
+  it('should update metabase version', async () => {
+    const addon = await support.createTestAddon({
+      name: 'test-metabase-addon',
+      providerId: 'metabase',
+      planId: 'plan_2925d534-7155-4521-8052-d068d7ce8915',
+    });
+    const info = await support.client.send(new GetMetabaseInfoCommand({ addonId: addon.id }));
+
+    const response = await support.client.send(
+      new UpdateMetabaseVersionCommand({ addonId: addon.id, targetVersion: info.version }),
+    );
+
+    expect(response.id).to.equal(addon.realId);
+    expect(response.version).to.be.a('string');
+    expect(response.environment).to.be.an('array');
+  });
+});

--- a/test/e2e/clients/cc-api/commands/otoroshi-commands.spec.js
+++ b/test/e2e/clients/cc-api/commands/otoroshi-commands.spec.js
@@ -1,0 +1,147 @@
+import { expect } from 'chai';
+import { CheckOtoroshiVersionCommand } from '../../../../../src/clients/cc-api/commands/otoroshi/check-otoroshi-version-command.js';
+import { CreateOtoroshiNetworkGroupCommand } from '../../../../../src/clients/cc-api/commands/otoroshi/create-otoroshi-network-group-command.js';
+import { DeleteOtoroshiNetworkGroupCommand } from '../../../../../src/clients/cc-api/commands/otoroshi/delete-otoroshi-network-group-command.js';
+import { GetOtoroshiConfigCommand } from '../../../../../src/clients/cc-api/commands/otoroshi/get-otoroshi-config-command.js';
+import { GetOtoroshiInfoCommand } from '../../../../../src/clients/cc-api/commands/otoroshi/get-otoroshi-info-command.js';
+import { RebootOtoroshiCommand } from '../../../../../src/clients/cc-api/commands/otoroshi/reboot-otoroshi-command.js';
+import { RebuildOtoroshiCommand } from '../../../../../src/clients/cc-api/commands/otoroshi/rebuild-otoroshi-command.js';
+import { UpdateOtoroshiVersionCommand } from '../../../../../src/clients/cc-api/commands/otoroshi/update-otoroshi-version-command.js';
+import { e2eSupport } from '../e2e-support.js';
+
+describe('otoroshi commands', function () {
+  const support = e2eSupport();
+
+  before(async () => {
+    await support.prepare();
+  });
+
+  afterEach(async () => {
+    await support.deleteAddons();
+  });
+
+  after(async () => {
+    await support.cleanup();
+  });
+
+  it('should get otoroshi info', async () => {
+    const addon = await support.createTestAddon({
+      name: 'test-otoroshi-addon',
+      providerId: 'otoroshi',
+      planId: 'plan_d738ee0f-8720-499a-8067-2fca53a2665a',
+    });
+    const response = await support.client.send(new GetOtoroshiInfoCommand({ addonId: addon.id }));
+
+    expect(response.id).to.equal(addon.realId);
+    expect(response.addonId).to.equal(addon.id);
+    expect(response.name).to.equal(addon.name);
+    expect(response.ownerId).to.equal(support.organisationId);
+    expect(response.plan).to.be.a('string');
+    expect(response.version).to.be.a('string');
+    expect(response.javaVersion).to.be.a('string');
+    expect(response.accessUrl).to.be.a('string');
+    expect(response.availableVersions).to.be.an('array');
+    expect(response.resources.entrypoint).to.be.a('string');
+    expect(response.resources.redisId).to.be.a('string');
+    expect(response.api.url).to.be.a('string');
+    expect(response.api.user).to.be.a('string');
+    expect(response.api.secret).to.be.a('string');
+    expect(response.api.openapi).to.be.a('string');
+    expect(response.initialCredentials.user).to.be.a('string');
+    expect(response.initialCredentials.password).to.be.a('string');
+    expect(response.features).to.be.an('object');
+    expect(response.environment).to.be.an('array');
+  });
+
+  it('should reboot otoroshi', async () => {
+    const addon = await support.createTestAddon({
+      name: 'test-otoroshi-addon',
+      providerId: 'otoroshi',
+      planId: 'plan_d738ee0f-8720-499a-8067-2fca53a2665a',
+    });
+    const response = await support.client.send(new RebootOtoroshiCommand({ addonId: addon.id }));
+
+    expect(response).to.be.null;
+  });
+
+  it('should rebuild otoroshi', async () => {
+    const addon = await support.createTestAddon({
+      name: 'test-otoroshi-addon',
+      providerId: 'otoroshi',
+      planId: 'plan_d738ee0f-8720-499a-8067-2fca53a2665a',
+    });
+    const response = await support.client.send(new RebuildOtoroshiCommand({ addonId: addon.id }));
+
+    expect(response).to.be.null;
+  });
+
+  it('should check otoroshi version', async () => {
+    const addon = await support.createTestAddon({
+      name: 'test-otoroshi-addon',
+      providerId: 'otoroshi',
+      planId: 'plan_d738ee0f-8720-499a-8067-2fca53a2665a',
+    });
+    const response = await support.client.send(new CheckOtoroshiVersionCommand({ addonId: addon.id }));
+
+    expect(response.installed).to.be.a('string');
+    expect(response.latest).to.be.a('string');
+    expect(response.available).to.be.an('array').that.includes(response.latest);
+    expect(response.needUpdate).to.be.a('boolean');
+  });
+
+  it('should update otoroshi version', async () => {
+    const addon = await support.createTestAddon({
+      name: 'test-otoroshi-addon',
+      providerId: 'otoroshi',
+      planId: 'plan_d738ee0f-8720-499a-8067-2fca53a2665a',
+    });
+    const info = await support.client.send(new GetOtoroshiInfoCommand({ addonId: addon.id }));
+
+    const response = await support.client.send(
+      new UpdateOtoroshiVersionCommand({ addonId: addon.id, targetVersion: info.version }),
+    );
+
+    expect(response.id).to.equal(addon.realId);
+    expect(response.version).to.be.a('string');
+    expect(response.environment).to.be.an('array');
+  });
+
+  it('should create otoroshi network group', async () => {
+    const addon = await support.createTestAddon({
+      name: 'test-otoroshi-addon',
+      providerId: 'otoroshi',
+      planId: 'plan_d738ee0f-8720-499a-8067-2fca53a2665a',
+    });
+    const response = await support.client.send(new CreateOtoroshiNetworkGroupCommand({ addonId: addon.id }));
+
+    expect(response.id).to.equal(addon.realId);
+    expect(response.features.networkGroup).to.not.be.null;
+    expect(response.features.networkGroup.id).to.be.a('string');
+  });
+
+  it('should delete otoroshi network group', async () => {
+    const addon = await support.createTestAddon({
+      name: 'test-otoroshi-addon',
+      providerId: 'otoroshi',
+      planId: 'plan_d738ee0f-8720-499a-8067-2fca53a2665a',
+    });
+    // Create a network group first so we can delete it
+    await support.client.send(new CreateOtoroshiNetworkGroupCommand({ addonId: addon.id }));
+
+    const response = await support.client.send(new DeleteOtoroshiNetworkGroupCommand({ addonId: addon.id }));
+
+    expect(response).to.be.null;
+  });
+
+  it('should get otoroshi config', async () => {
+    const addon = await support.createTestAddon({
+      name: 'test-otoroshi-addon',
+      providerId: 'otoroshi',
+      planId: 'plan_d738ee0f-8720-499a-8067-2fca53a2665a',
+    });
+    const response = await support.client.send(new GetOtoroshiConfigCommand({ addonId: addon.id }));
+
+    expect(response).to.be.a('string');
+    expect(response.length).to.be.greaterThan(0);
+  });
+});


### PR DESCRIPTION
FIxes #156 

## What does this PR do?

- Adds commands for each operator,
- Fixes small issues with Matomo types and docs.

## How to review?

- Check the commits,
- Run e2e tests locally.