### PR TITLE
fix(streams): improve WebSocket reconnection stability

### DIFF
--- a/esm/streams/events.js
+++ b/esm/streams/events.js
@@ -24,7 +24,7 @@ export class EventsStream extends AbstractStream {
   /**
    * @param {Object} options
    * @param {String} options.apiHost
-   * @param {OAuthTokens} options.tokens
+   * @param {OAuthTokens | (() => OAuthTokens)} options.tokens
    * @param {String} [options.appId]
    */
   constructor({ apiHost, tokens, appId }) {
@@ -114,7 +114,7 @@ export class EventsStream extends AbstractStream {
       url: '/v2/events/',
     })
       .then(prefixUrl(this.apiHost))
-      .then(addOauthHeader(this.tokens))
+      .then(addOauthHeader(typeof this.tokens === 'function' ? this.tokens() : this.tokens))
       .then((requestParams) => {
         // prepare WebSocket URL from URL used for signature
         const urlObj = new URL(requestParams.url);

--- a/esm/streams/stream.abstract.js
+++ b/esm/streams/stream.abstract.js
@@ -7,7 +7,8 @@ import EventEmitter from 'component-emitter';
 const BACKOFF_FACTOR = 1.25;
 const INIT_RETRY_TIMEOUT = 1500;
 const MAX_RETRY_COUNT = Infinity;
-const PING_TIMEOUT_FACTOR = 1.25;
+const MAX_BACKOFF_DELAY = 30000;
+const PING_TIMEOUT_FACTOR = 3.0;
 
 export const AUTHENTICATION_REASON = {
   type: 'close',
@@ -87,7 +88,7 @@ export class AbstractStream extends EventEmitter {
     this._closeSource();
     // Always clear all timeouts
     clearTimeout(this._pingTimeoutId);
-    clearTimeout(this._autoRetry.timeoutId);
+    clearTimeout(this._autoRetry?.timeoutId);
     this.emit('close', reason);
   }
 
@@ -126,9 +127,12 @@ export class AbstractStream extends EventEmitter {
       this._autoRetry.counter = 0;
     }
     clearTimeout(this._pingTimeoutId);
-    this._pingTimeoutId = setTimeout(() => {
-      this._onError(new PingError('Stream failed to send ping within timeframe'));
-    }, delay * PING_TIMEOUT_FACTOR);
+    this._pingTimeoutId = setTimeout(
+      () => {
+        this._onError(new PingError('Stream failed to send ping within timeframe'));
+      },
+      delay * (this._autoRetry?.pingTimeoutFactor ?? PING_TIMEOUT_FACTOR),
+    );
   }
 
   /**
@@ -154,8 +158,11 @@ export class AbstractStream extends EventEmitter {
         return this.emit('error', new Error(`Stream connection failed ${this._autoRetry.maxRetryCount} times!`));
       }
 
-      const exponentialBackoffDelay =
-        this._autoRetry.initRetryTimeout * this._autoRetry.backoffFactor ** this._autoRetry.counter;
+      const baseDelay = Math.min(
+        this._autoRetry.initRetryTimeout * this._autoRetry.backoffFactor ** this._autoRetry.counter,
+        MAX_BACKOFF_DELAY,
+      );
+      const exponentialBackoffDelay = baseDelay * (0.75 + Math.random() * 0.5); // ±25% jitter
       this._autoRetry.timeoutId = setTimeout(() => {
         this.emit('open');
         this._openSource().catch((error) => this._onError(error));


### PR DESCRIPTION
## Summary
- Increase `PING_TIMEOUT_FACTOR` from `1.25` to `3.0` — with a 2s heartbeat this gives 6s margin instead of 500ms, tolerating GC pauses, network jitter, and browser tab throttling
- Cap exponential backoff delay at 30s with ±25% random jitter to prevent thundering herd on mass reconnects
- Support `tokens` as a function in `EventsStream` to enable token refresh on reconnect (backward compatible with static token objects)

## Test plan
- [ ] Verify heartbeat is received every 2s and no false ping timeouts occur within 6s
- [ ] Throttle network and verify client reconnects with capped backoff (max ~30s)
- [ ] Pass `tokens: () => getTokens()` and verify fresh tokens are used on each reconnect
- [ ] Pass static `tokens: { ... }` and verify backward compatibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)