### PR TITLE
fix(events): use ws:// when API host is http:// (dev mode support)

### DIFF
--- a/esm/streams/events.js
+++ b/esm/streams/events.js
@@ -118,7 +118,7 @@ export class EventsStream extends AbstractStream {
       .then((requestParams) => {
         // prepare WebSocket URL from URL used for signature
         const urlObj = new URL(requestParams.url);
-        urlObj.protocol = 'wss:';
+        urlObj.protocol = urlObj.protocol === 'http:' ? 'ws:' : 'wss:';
         urlObj.pathname = urlObj.pathname + 'event-socket';
         const url = urlObj.toString();
         // prepare message to auth WebSocket


### PR DESCRIPTION
## Problem

EventsStream always forces `wss:` protocol for the WebSocket connection, even when the API host uses `http://`. This breaks local development environments where TLS is not configured.

## Fix

```diff
-        urlObj.protocol = 'wss:';
+        urlObj.protocol = urlObj.protocol === 'http:' ? 'ws:' : 'wss:';
```

Use `ws:` when the API host protocol is `http:`, `wss:` otherwise. This is backward-compatible — production environments using `https://` will continue to use `wss:` as before.

## Context

Discovered during the Clever Cloud Rust monolith migration (`clevercloud-rust-rebuilt`). The dev-runner serves the full API on HTTP without TLS, and Console3's EventsStream fails silently because it tries `wss://localhost:8080` which has no TLS certificate.