### PR TITLE
feat(network-groups): add helpers to filter out unsupported add-ons

### DIFF
--- a/src/clients/cc-api/commands/network-group/network-group-utils.js
+++ b/src/clients/cc-api/commands/network-group/network-group-utils.js
@@ -2,6 +2,7 @@
  * @import { NetworkGroup, NetworkGroupMember, NetworkGroupPeer } from './network-group.types.js'
  * @import { CcApiType, CcApiCommand } from '../../types/cc-api.types.js'
  * @import { Composer } from '../../../../types/command.types.js'
+ * @import { Addon } from '../addon/addon.types.js'
  */
 import { randomUUID } from '../../../../lib/utils.js';
 import { isTimeoutError, Polling } from '../../../../utils/polling.js';
@@ -146,6 +147,32 @@ function getKind(memberId) {
     return 'EXTERNAL';
   }
   throw new Error(`Invalid member id "${memberId}". Member id must be "addon_xxx", "app_xxx" or "external_xxx"`);
+}
+
+/**
+ * The set of addon provider IDs that are valid network group member candidates.
+ *
+ * @type {Set<string>}
+ */
+export const NETWORK_GROUP_SUPPORTED_ADDON_PROVIDER_IDS = new Set([
+  'es-addon',
+  'mongodb-addon',
+  'mysql-addon',
+  'postgresql-addon',
+  'redis-addon',
+]);
+
+/**
+ * Returns true if the given addon is a valid network group member candidate.
+ * An addon is a valid candidate if:
+ * - Its provider ID is in NETWORK_GROUP_SUPPORTED_ADDON_PROVIDER_IDS
+ * - Its plan slug is not "dev"
+ *
+ * @param {Addon} addon
+ * @returns {boolean}
+ */
+export function isNetworkGroupAddonCandidate(addon) {
+  return NETWORK_GROUP_SUPPORTED_ADDON_PROVIDER_IDS.has(addon.provider.id) && addon.plan.slug !== 'dev';
 }
 
 /**

--- a/test/unit/clients/cc-api/commands/network-group/network-group-utils.spec.js
+++ b/test/unit/clients/cc-api/commands/network-group/network-group-utils.spec.js
@@ -1,0 +1,42 @@
+import { expect } from 'chai';
+import {
+  NETWORK_GROUP_SUPPORTED_ADDON_PROVIDER_IDS,
+  isNetworkGroupAddonCandidate,
+} from '../../../../../../src/clients/cc-api/commands/network-group/network-group-utils.js';
+
+/**
+ * @param {{ providerId?: string, planSlug?: string }} [overrides]
+ * @returns {import('../../../../../../src/clients/cc-api/commands/addon/addon.types.js').Addon}
+ */
+function makeAddon({ providerId = 'postgresql-addon', planSlug = 'xsmall' } = {}) {
+  return /** @type {any} */ ({ provider: { id: providerId }, plan: { slug: planSlug } });
+}
+
+describe('isNetworkGroupAddonCandidate', () => {
+  it('should return true for each of the 5 supported providers with a non-dev plan', () => {
+    for (const providerId of NETWORK_GROUP_SUPPORTED_ADDON_PROVIDER_IDS) {
+      const addon = makeAddon({ providerId, planSlug: 'xsmall' });
+      expect(isNetworkGroupAddonCandidate(addon), `provider: ${providerId}`).to.equal(true);
+    }
+  });
+
+  it('should return false for a supported provider with plan slug "dev"', () => {
+    const addon = makeAddon({ providerId: 'postgresql-addon', planSlug: 'dev' });
+    expect(isNetworkGroupAddonCandidate(addon)).to.equal(false);
+  });
+
+  it('should return false for an unsupported provider (keycloak)', () => {
+    const addon = makeAddon({ providerId: 'keycloak', planSlug: 'xsmall' });
+    expect(isNetworkGroupAddonCandidate(addon)).to.equal(false);
+  });
+
+  it('should return false for an unsupported provider (addon-pulsar)', () => {
+    const addon = makeAddon({ providerId: 'addon-pulsar', planSlug: 'xsmall' });
+    expect(isNetworkGroupAddonCandidate(addon)).to.equal(false);
+  });
+
+  it('should return false for an unsupported provider with dev plan', () => {
+    const addon = makeAddon({ providerId: 'fs-bucket', planSlug: 'dev' });
+    expect(isNetworkGroupAddonCandidate(addon)).to.equal(false);
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Adds two helpers:
- `NETWORK_GROUP_SUPPORTED_ADDON_PROVIDER_IDS` to get the list of provider IDs that support Network Groups,
- `isNetworkGroupAddonCandidate(addon)` to filter a list of add-ons  (filters out unsupported providers and `dev` plans).

<details>
  <summary><h2>Why we need this and how it'll be used in the console</h2></summary>

### Console menu (Network Groups tab visibility)

The menu only filters on the **allowed `providerId`s** to decide whether the Network Groups tab is displayed.

### Dev plans

The tab is **available**, but the page shows a **specific message** telling the user to upgrade their plan if they want to access the feature.

### Operator sub-resources ("spare parts")

Available as well. It can be useful — though very unlikely — if someone wants to add an external peer to reach the app or DB of their Matomo, for example. Note: Matomo will keep communicating between its own resources without the Network Group anyway.
It's not perfect, but it stems from a **design issue with operators**: we already expose TCP redirs and env variables on these apps/add-ons even though it doesn't really make sense.

### Dropdowns for adding resources to a NG

We simply filter on:
- `providerId` is one of the supported add-ons (PG, etc.)
- `plan !== 'dev'`

</details>

## How to review?

- 1 reviewer should be enough for this one,
- Are the helpers named correctly? 
- Are the helpers exposed from the right file?
- Are tests worth it / relevant?
- [x] @florian-sanders-cc try it in the console & components to make sure we have all we need.