### PR TITLE
fix(network-group): allow using `realId` to add addons as members

### DIFF
--- a/src/clients/cc-api/commands/network-group/network-group-utils.js
+++ b/src/clients/cc-api/commands/network-group/network-group-utils.js
@@ -98,7 +98,7 @@ export async function waitForNetworkGroupPeerDeletion(composer, ownerId, network
  *
  * @param {string} ngId The Network Group ID
  * @param {string} memberId The member ID
- * @returns {Object}
+ * @returns {Omit<NetworkGroupMember, 'label'>}
  */
 export function constructNetworkGroupMember(ngId, memberId) {
   return {
@@ -140,39 +140,48 @@ function getKind(memberId) {
   if (memberId.startsWith('app_')) {
     return 'APPLICATION';
   }
-  if (memberId.startsWith('addon_')) {
-    return 'ADDON';
-  }
   if (memberId.startsWith('external_')) {
     return 'EXTERNAL';
   }
-  throw new Error(`Invalid member id "${memberId}". Member id must be "addon_xxx", "app_xxx" or "external_xxx"`);
+  for (const realIdPrefix of NETWORK_GROUP_SUPPORTED_ADDON_PROVIDERS.values()) {
+    if (memberId.startsWith(realIdPrefix)) {
+      return 'ADDON';
+    }
+  }
+  const validPrefixes = [...NETWORK_GROUP_SUPPORTED_ADDON_PROVIDERS.values(), 'app_', 'external_']
+    .map((p) => `"${p}xxx"`)
+    .join(', ');
+  throw new Error(`Invalid member id "${memberId}". Member id must start with one of: ${validPrefixes}`);
 }
 
 /**
- * The set of addon provider IDs that are valid network group member candidates.
+ * Maps each supported addon provider ID to the realId prefix used by the Clever Cloud API.
+ * Both facts (supported providers and their realId prefixes) are kept here to prevent drift.
  *
- * @type {Set<string>}
+ * key   — provider ID (e.g. 'postgresql-addon')
+ * value — realId prefix (e.g. 'postgresql_')
+ *
+ * @type {Map<string, string>}
  */
-export const NETWORK_GROUP_SUPPORTED_ADDON_PROVIDER_IDS = new Set([
-  'es-addon',
-  'mongodb-addon',
-  'mysql-addon',
-  'postgresql-addon',
-  'redis-addon',
+export const NETWORK_GROUP_SUPPORTED_ADDON_PROVIDERS = new Map([
+  ['es-addon', 'elasticsearch_'],
+  ['mongodb-addon', 'mongodb_'],
+  ['mysql-addon', 'mysql_'],
+  ['postgresql-addon', 'postgresql_'],
+  ['redis-addon', 'redis_'],
 ]);
 
 /**
  * Returns true if the given addon is a valid network group member candidate.
  * An addon is a valid candidate if:
- * - Its provider ID is in NETWORK_GROUP_SUPPORTED_ADDON_PROVIDER_IDS
+ * - Its provider ID is in NETWORK_GROUP_SUPPORTED_ADDON_PROVIDERS
  * - Its plan slug is not "dev"
  *
  * @param {Addon} addon
  * @returns {boolean}
  */
 export function isNetworkGroupAddonCandidate(addon) {
-  return NETWORK_GROUP_SUPPORTED_ADDON_PROVIDER_IDS.has(addon.provider.id) && addon.plan.slug !== 'dev';
+  return NETWORK_GROUP_SUPPORTED_ADDON_PROVIDERS.has(addon.provider.id) && addon.plan.slug !== 'dev';
 }
 
 /**

--- a/test/e2e/clients/cc-api/commands/network-group-commands.spec.js
+++ b/test/e2e/clients/cc-api/commands/network-group-commands.spec.js
@@ -24,7 +24,7 @@ describe('network-group commands', function () {
   });
 
   afterEach(async () => {
-    await Promise.all([support.deleteApplications(), support.deleteNetworkGroups()]);
+    await Promise.all([support.deleteApplications(), support.deleteAddons(), support.deleteNetworkGroups()]);
   });
 
   it('should get network group', async () => {
@@ -322,5 +322,220 @@ describe('network-group commands', function () {
     );
 
     expect(response).to.have.lengthOf(2);
+  });
+
+  it('should create network group member with es-addon addon', async () => {
+    const addon = await support.createTestAddon({
+      providerId: 'es-addon',
+      planId: 'plan_0e0bc5ea-ba21-41e8-865b-1ed48e0163ca',
+      zone: 'par',
+      name: 'test-ng-es-addon',
+    });
+    const createdNetworkGroup = await support.createNetworkGroup();
+
+    const response = await support.client.send(
+      new CreateNetworkGroupMemberCommand({
+        ownerId: support.organisationId,
+        networkGroupId: createdNetworkGroup.id,
+        memberId: addon.realId,
+        label: 'label',
+      }),
+    );
+
+    expect(response.id).to.equal(addon.realId);
+    expect(response.kind).to.equal('ADDON');
+    expect(response.label).to.equal('label');
+  });
+
+  it('should delete network group member with es-addon addon', async () => {
+    const addon = await support.createTestAddon({
+      providerId: 'es-addon',
+      planId: 'plan_0e0bc5ea-ba21-41e8-865b-1ed48e0163ca',
+      zone: 'par',
+      name: 'test-ng-es-addon',
+    });
+    const createdNetworkGroup = await support.createNetworkGroup(addon.realId);
+
+    const response = await support.client.send(
+      new DeleteNetworkGroupMemberCommand({
+        ownerId: support.organisationId,
+        networkGroupId: createdNetworkGroup.id,
+        memberId: addon.realId,
+      }),
+    );
+
+    expect(response).to.be.null;
+  });
+
+  it('should create network group member with mongodb-addon addon', async () => {
+    const addon = await support.createTestAddon({
+      providerId: 'mongodb-addon',
+      planId: 'plan_b53983a2-63d3-472d-8c98-f1bdea682912',
+      zone: 'par',
+      name: 'test-ng-mongodb-addon',
+    });
+    const createdNetworkGroup = await support.createNetworkGroup();
+
+    const response = await support.client.send(
+      new CreateNetworkGroupMemberCommand({
+        ownerId: support.organisationId,
+        networkGroupId: createdNetworkGroup.id,
+        memberId: addon.realId,
+        label: 'label',
+      }),
+    );
+
+    expect(response.id).to.equal(addon.realId);
+    expect(response.kind).to.equal('ADDON');
+    expect(response.label).to.equal('label');
+  });
+
+  it('should delete network group member with mongodb-addon addon', async () => {
+    const addon = await support.createTestAddon({
+      providerId: 'mongodb-addon',
+      planId: 'plan_b53983a2-63d3-472d-8c98-f1bdea682912',
+      zone: 'par',
+      name: 'test-ng-mongodb-addon',
+    });
+    const createdNetworkGroup = await support.createNetworkGroup(addon.realId);
+
+    const response = await support.client.send(
+      new DeleteNetworkGroupMemberCommand({
+        ownerId: support.organisationId,
+        networkGroupId: createdNetworkGroup.id,
+        memberId: addon.realId,
+      }),
+    );
+
+    expect(response).to.be.null;
+  });
+
+  it('should create network group member with mysql-addon addon', async () => {
+    const addon = await support.createTestAddon({
+      providerId: 'mysql-addon',
+      planId: 'plan_7ab494e2-c319-4330-8170-35d78738c1ee',
+      zone: 'par',
+      name: 'test-ng-mysql-addon',
+    });
+    const createdNetworkGroup = await support.createNetworkGroup();
+
+    const response = await support.client.send(
+      new CreateNetworkGroupMemberCommand({
+        ownerId: support.organisationId,
+        networkGroupId: createdNetworkGroup.id,
+        memberId: addon.realId,
+        label: 'label',
+      }),
+    );
+
+    expect(response.id).to.equal(addon.realId);
+    expect(response.kind).to.equal('ADDON');
+    expect(response.label).to.equal('label');
+  });
+
+  it('should delete network group member with mysql-addon addon', async () => {
+    const addon = await support.createTestAddon({
+      providerId: 'mysql-addon',
+      planId: 'plan_7ab494e2-c319-4330-8170-35d78738c1ee',
+      zone: 'par',
+      name: 'test-ng-mysql-addon',
+    });
+    const createdNetworkGroup = await support.createNetworkGroup(addon.realId);
+
+    const response = await support.client.send(
+      new DeleteNetworkGroupMemberCommand({
+        ownerId: support.organisationId,
+        networkGroupId: createdNetworkGroup.id,
+        memberId: addon.realId,
+      }),
+    );
+
+    expect(response).to.be.null;
+  });
+
+  it('should create network group member with postgresql-addon addon', async () => {
+    const addon = await support.createTestAddon({
+      providerId: 'postgresql-addon',
+      planId: 'plan_c32d00fb-6c06-48a9-a0a3-9d808937ec68',
+      zone: 'par',
+      name: 'test-ng-postgresql-addon',
+    });
+    const createdNetworkGroup = await support.createNetworkGroup();
+
+    const response = await support.client.send(
+      new CreateNetworkGroupMemberCommand({
+        ownerId: support.organisationId,
+        networkGroupId: createdNetworkGroup.id,
+        memberId: addon.realId,
+        label: 'label',
+      }),
+    );
+
+    expect(response.id).to.equal(addon.realId);
+    expect(response.kind).to.equal('ADDON');
+    expect(response.label).to.equal('label');
+  });
+
+  it('should delete network group member with postgresql-addon addon', async () => {
+    const addon = await support.createTestAddon({
+      providerId: 'postgresql-addon',
+      planId: 'plan_c32d00fb-6c06-48a9-a0a3-9d808937ec68',
+      zone: 'par',
+      name: 'test-ng-postgresql-addon',
+    });
+    const createdNetworkGroup = await support.createNetworkGroup(addon.realId);
+
+    const response = await support.client.send(
+      new DeleteNetworkGroupMemberCommand({
+        ownerId: support.organisationId,
+        networkGroupId: createdNetworkGroup.id,
+        memberId: addon.realId,
+      }),
+    );
+
+    expect(response).to.be.null;
+  });
+
+  it('should create network group member with redis-addon addon', async () => {
+    const addon = await support.createTestAddon({
+      providerId: 'redis-addon',
+      planId: 'plan_c62dd71e-15c3-483e-879d-75e4c836e21e',
+      zone: 'par',
+      name: 'test-ng-redis-addon',
+    });
+    const createdNetworkGroup = await support.createNetworkGroup();
+
+    const response = await support.client.send(
+      new CreateNetworkGroupMemberCommand({
+        ownerId: support.organisationId,
+        networkGroupId: createdNetworkGroup.id,
+        memberId: addon.realId,
+        label: 'label',
+      }),
+    );
+
+    expect(response.id).to.equal(addon.realId);
+    expect(response.kind).to.equal('ADDON');
+    expect(response.label).to.equal('label');
+  });
+
+  it('should delete network group member with redis-addon addon', async () => {
+    const addon = await support.createTestAddon({
+      providerId: 'redis-addon',
+      planId: 'plan_c62dd71e-15c3-483e-879d-75e4c836e21e',
+      zone: 'par',
+      name: 'test-ng-redis-addon',
+    });
+    const createdNetworkGroup = await support.createNetworkGroup(addon.realId);
+
+    const response = await support.client.send(
+      new DeleteNetworkGroupMemberCommand({
+        ownerId: support.organisationId,
+        networkGroupId: createdNetworkGroup.id,
+        memberId: addon.realId,
+      }),
+    );
+
+    expect(response).to.be.null;
   });
 });

--- a/test/unit/clients/cc-api/commands/network-group/network-group-utils.spec.js
+++ b/test/unit/clients/cc-api/commands/network-group/network-group-utils.spec.js
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import {
-  NETWORK_GROUP_SUPPORTED_ADDON_PROVIDER_IDS,
+  NETWORK_GROUP_SUPPORTED_ADDON_PROVIDERS,
+  constructNetworkGroupMember,
   isNetworkGroupAddonCandidate,
 } from '../../../../../../src/clients/cc-api/commands/network-group/network-group-utils.js';
 
@@ -14,7 +15,7 @@ function makeAddon({ providerId = 'postgresql-addon', planSlug = 'xsmall' } = {}
 
 describe('isNetworkGroupAddonCandidate', () => {
   it('should return true for each of the 5 supported providers with a non-dev plan', () => {
-    for (const providerId of NETWORK_GROUP_SUPPORTED_ADDON_PROVIDER_IDS) {
+    for (const providerId of NETWORK_GROUP_SUPPORTED_ADDON_PROVIDERS.keys()) {
       const addon = makeAddon({ providerId, planSlug: 'xsmall' });
       expect(isNetworkGroupAddonCandidate(addon), `provider: ${providerId}`).to.equal(true);
     }
@@ -38,5 +39,46 @@ describe('isNetworkGroupAddonCandidate', () => {
   it('should return false for an unsupported provider with dev plan', () => {
     const addon = makeAddon({ providerId: 'fs-bucket', planSlug: 'dev' });
     expect(isNetworkGroupAddonCandidate(addon)).to.equal(false);
+  });
+});
+
+describe('constructNetworkGroupMember', () => {
+  const NG_ID = 'ng_test-ng-id';
+
+  it('should return kind APPLICATION for an app_ member id', () => {
+    const member = constructNetworkGroupMember(NG_ID, 'app_abc123');
+    expect(member.kind).to.equal('APPLICATION');
+  });
+
+  it('should return kind EXTERNAL for an external_ member id', () => {
+    const member = constructNetworkGroupMember(NG_ID, 'external_abc123');
+    expect(member.kind).to.equal('EXTERNAL');
+  });
+
+  it('should return kind ADDON for each supported addon realId prefix', () => {
+    const realIdPrefixes = [...NETWORK_GROUP_SUPPORTED_ADDON_PROVIDERS.values()];
+    for (const prefix of realIdPrefixes) {
+      const memberId = `${prefix}abc123`;
+      const member = constructNetworkGroupMember(NG_ID, memberId);
+      expect(member.kind, `realId prefix: ${prefix}`).to.equal('ADDON');
+    }
+  });
+
+  it('should throw for a legacy addon_ id (regression: addon_ is no longer accepted)', () => {
+    expect(() => constructNetworkGroupMember(NG_ID, 'addon_abc123')).to.throw();
+  });
+
+  it('should throw for a completely unknown member id prefix', () => {
+    expect(() => constructNetworkGroupMember(NG_ID, 'unknown_abc123')).to.throw();
+  });
+
+  it('should build the correct domainName', () => {
+    const member = constructNetworkGroupMember(NG_ID, 'app_abc123');
+    expect(member.domainName).to.equal('app_abc123.m.ng_test-ng-id.cc-ng.cloud');
+  });
+
+  it('should echo back the member id', () => {
+    const member = constructNetworkGroupMember(NG_ID, 'app_abc123');
+    expect(member.id).to.equal('app_abc123');
   });
 });


### PR DESCRIPTION
Fixes #204

## What does this PR do?

Network group member creation failed because the client rejected valid addon IDs (`realId`) and accepted invalid ones (`addon_`).
- Fix the client-side validation so it recognises the correct addon ID format (`realId`).
- Also rename and reshape the exported `NETWORK_GROUP_SUPPORTED_ADDON_PROVIDER_IDS` from a `Set` to a `Map` named `NETWORK_GROUP_SUPPORTED_ADDON_PROVIDERS` so each supported provider is paired with its expected ID prefix, keeping both pieces of information in  sync.
- Adds e2e tests for add-ons as NG members.

## Alternatives considers

- Not relying on id prefixes would be better but it would force to fetch data about each resource first to validate info. It's not a big API call but it's one per potential member that's not an app or external... 
  - I'm fine to refactor this way if you think it's worth it :+1: 

## How to review?

- Check the commit,
- run e2e tests locally,
- 1 reviewer should be enough.