### PR TITLE
fix(cc-api-client): use deletionDate from payload for instance deletionDate

### DIFF
--- a/src/clients/cc-api/commands/instance/instance-transform.js
+++ b/src/clients/cc-api/commands/instance/instance-transform.js
@@ -21,7 +21,7 @@ export function transformApplicationInstance(payload) {
     state: payload.state,
     hypervisorId: payload.hypervisorId,
     creationDate: normalizeDate(payload.creationDate),
-    deletionDate: normalizeDate(payload.creationDate),
+    deletionDate: normalizeDate(payload.deletionDate),
     network: payload.network,
     isBuildVm: payload.isBuildVm,
   };


### PR DESCRIPTION
## Context

`transformApplicationInstance` was reading `deletionDate` from `payload.creationDate`, so every
instance returned by the cc-api client reported its creation timestamp as its deletion timestamp.
Consumers relying on `deletionDate` to detect or order terminated instances were getting wrong
data, and running instances appeared "deleted" at their creation time instead of `null`.

## Changes

- Read `deletionDate` from `payload.deletionDate` in `instance-transform.js` instead of
  `payload.creationDate`.

## How to review

1. Read `src/clients/cc-api/commands/instance/instance-transform.js` — the one-line fix is the
   whole change.
2. Confirm `creationDate` and `deletionDate` now map to their respective payload fields.

**1 approval** from a cc-api-client maintainer.