### PR TITLE
fix(application-commands): support `ftp` applications

### DIFF
--- a/src/clients/cc-api/commands/application/application-transform.js
+++ b/src/clients/cc-api/commands/application/application-transform.js
@@ -78,5 +78,5 @@ export function transformApplication(payload) {
  * @returns {boolean}
  */
 export function isGithubApplication(payload) {
-  return payload.deployment.httpUrl.startsWith('https://github.com');
+  return payload.deployment.httpUrl?.startsWith('https://github.com') ?? false;
 }

--- a/src/clients/cc-api/commands/application/application.types.d.ts
+++ b/src/clients/cc-api/commands/application/application.types.d.ts
@@ -28,7 +28,7 @@ export interface Application {
     type: ApplicationDeploymentType;
     repoState: ApplicationRepositoryState;
     url: string;
-    httpUrl: string;
+    httpUrl?: string;
   };
   // renamed from vhosts
   domains: Array<Domain>;

--- a/test/e2e/clients/cc-api/commands/application-commands.spec.js
+++ b/test/e2e/clients/cc-api/commands/application-commands.spec.js
@@ -110,4 +110,32 @@ describe('application commands', function () {
 
     expect(response).to.have.length(0);
   });
+
+  it('should create FTP application', async () => {
+    const application = await support.createFtpApplication();
+
+    expect(application.id).to.match(/app_.+/);
+    expect(application.ownerId).to.equal(support.organisationId);
+    expect(application.deployment.type).to.equal('FTP');
+  });
+
+  it('should get FTP application', async () => {
+    const application = await support.createFtpApplication();
+    const response = await support.client.send(
+      new GetApplicationCommand({ applicationId: application.id, withBranches: false }),
+    );
+
+    expect(response.id).to.equal(application.id);
+    expect(response.deployment.type).to.equal('FTP');
+  });
+
+  it('should list FTP application', async () => {
+    const application = await support.createFtpApplication();
+    const response = await support.client.send(
+      new ListApplicationCommand({ ownerId: support.organisationId, withBranches: false }),
+    );
+
+    expect(response.map((a) => a.id)).to.include(application.id);
+    expect(response.find((a) => a.id === application.id)?.deployment.type).to.equal('FTP');
+  });
 });

--- a/test/e2e/clients/cc-api/e2e-support.js
+++ b/test/e2e/clients/cc-api/e2e-support.js
@@ -297,6 +297,24 @@ export function e2eSupport(config) {
 
       return application;
     },
+    async createFtpApplication(name = 'test-application-ftp', ownerId = organisationId) {
+      const application = await this.client.send(
+        new CreateApplicationCommand({
+          ownerId,
+          name,
+          zone: 'par',
+          minInstances: 1,
+          maxInstances: 1,
+          minFlavor: 'xs',
+          maxFlavor: 'xs',
+          buildFlavor: 's',
+          instance: { slug: 'php' },
+          deploy: 'ftp',
+        }),
+      );
+      cleanupTasks.push({ type: 'application', id: application.id });
+      return application;
+    },
     /**
      * @param {Partial<CreateAddonCommandInput>} [addon]
      * @returns {Promise<Addon>}


### PR DESCRIPTION
Fixes #209

## What does this PR do?

The client assumed `httpUrl` was always set for applications but  `ftp` applications do not have any `httpUrl` set.

## How to review?

- Check the commit,
- Check the e2e tests,
- 1 reviewer should be enough for this one.
