### PR TITLE
Add dedupe request wrapper

### DIFF
--- a/src/clients/cc-api/commands/otoroshi/otoroshi-transform.js
+++ b/src/clients/cc-api/commands/otoroshi/otoroshi-transform.js
@@ -2,9 +2,6 @@
  * @import { OtoroshiInfo } from './otoroshi.types.js';
  */
 
-import { sortBy } from '../../../../lib/utils.js';
-import { toArray } from '../../../../utils/environment-utils.js';
-
 /**
  * @param {any} response
  * @returns {OtoroshiInfo}
@@ -24,6 +21,5 @@ export function transformOtoroshiInfo(response) {
     features: response.features,
     api: response.api,
     initialCredentials: response.initialCredentials,
-    environment: sortBy(toArray(response.envVars), 'name'),
   };
 }

--- a/src/clients/cc-api/commands/otoroshi/otoroshi.types.d.ts
+++ b/src/clients/cc-api/commands/otoroshi/otoroshi.types.d.ts
@@ -1,5 +1,3 @@
-import type { EnvironmentVariable } from '../../../../utils/environment.types.js';
-
 export interface OtoroshiInfo {
   id: string;
   addonId: string;
@@ -24,10 +22,10 @@ export interface OtoroshiInfo {
     user: string;
     secret: string;
     openapi: string;
+    swaggerUrl: string;
   };
   initialCredentials: {
     user: string;
     password: string;
   };
-  environment: Array<EnvironmentVariable>;
 }

--- a/src/lib/request/request-with-cache.js
+++ b/src/lib/request/request-with-cache.js
@@ -1,6 +1,8 @@
 /**
- * @import { RequestWrapper, CcRequestParams } from '../../types/request.types.js'
+ * @import { RequestWrapper } from '../../types/request.types.js'
  */
+
+import { calculateCacheKey } from '../utils.js';
 
 /**
  * @type {Map<string, { response: import('../../types/request.types.js').CcResponse<?>, expiresAt: number }>}
@@ -39,18 +41,4 @@ export async function requestWithCache(request, handler) {
   }
 
   return response;
-}
-
-/**
- * @param {Partial<CcRequestParams>} requestParams
- *  @returns {string}
- */
-function calculateCacheKey(requestParams) {
-  const cacheParams = [
-    requestParams.url,
-    requestParams.queryParams?.entries(),
-    requestParams.headers?.get('accept'),
-    requestParams.headers?.get('authorization'),
-  ];
-  return JSON.stringify(cacheParams);
 }

--- a/src/lib/request/request-with-dedupe.js
+++ b/src/lib/request/request-with-dedupe.js
@@ -1,0 +1,30 @@
+/**
+ * @import { RequestWrapper, CcResponse } from '../../types/request.types.js'
+ */
+
+import { calculateCacheKey } from '../utils.js';
+
+/**
+ * @type {Map<string, Promise<CcResponse<any>>>}
+ */
+const PENDING_FETCH_CACHE = new Map();
+
+/**
+ * @type {RequestWrapper}
+ */
+export async function requestWithDedupe(request, handler) {
+  // no dedupe on HTTP method other than GET
+  if (request.method.toLowerCase() !== 'get') {
+    return handler(request);
+  }
+
+  const cacheKey = calculateCacheKey(request);
+
+  if (PENDING_FETCH_CACHE.has(cacheKey)) {
+    return PENDING_FETCH_CACHE.get(cacheKey);
+  }
+
+  const promise = handler(request);
+  PENDING_FETCH_CACHE.set(cacheKey, promise);
+  return promise.finally(() => PENDING_FETCH_CACHE.delete(cacheKey));
+}

--- a/src/lib/request/request.js
+++ b/src/lib/request/request.js
@@ -6,6 +6,7 @@ import { CcClientError, CcRequestError } from '../error/cc-client-errors.js';
 import { fetchWithTimeout } from './fetch-with-timeout.js';
 import { requestDebug } from './request-debug.js';
 import { requestWithCache } from './request-with-cache.js';
+import { requestWithDedupe } from './request-with-dedupe.js';
 
 const JSON_TYPE = 'application/json';
 const EVENT_STREAM_CONTENT_TYPE = 'text/event-stream';
@@ -20,7 +21,7 @@ const NETWORK_ERROR_CODES = [
 ];
 
 /** @type {Array<RequestWrapper>} */
-const REQUEST_WRAPPERS = [requestWithCache, requestDebug];
+const REQUEST_WRAPPERS = [requestWithCache, requestWithDedupe, requestDebug];
 
 /**
  * @type {RequestAdapter}

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -1,5 +1,5 @@
 /**
- * @import { CcRequestConfig, CcRequestConfigPartial, RequestCachePolicy } from '../types/request.types.js'
+ * @import { CcRequestConfig, CcRequestConfigPartial, CcRequestParams, RequestCachePolicy } from '../types/request.types.js'
  */
 
 /**
@@ -337,6 +337,20 @@ export class Deferred {
   get reject() {
     return this.#reject;
   }
+}
+
+/**
+ * @param {Partial<CcRequestParams>} requestParams
+ * @returns {string}
+ */
+export function calculateCacheKey(requestParams) {
+  const cacheParams = [
+    requestParams.url,
+    requestParams.queryParams?.entries(),
+    requestParams.headers?.get('accept'),
+    requestParams.headers?.get('authorization'),
+  ];
+  return JSON.stringify(cacheParams);
 }
 
 /**

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -346,7 +346,7 @@ export class Deferred {
 export function calculateCacheKey(requestParams) {
   const cacheParams = [
     requestParams.url,
-    requestParams.queryParams?.entries(),
+    requestParams.queryParams?.toObject(),
     requestParams.headers?.get('accept'),
     requestParams.headers?.get('authorization'),
   ];

--- a/test/e2e/clients/cc-api/commands/otoroshi-commands.spec.js
+++ b/test/e2e/clients/cc-api/commands/otoroshi-commands.spec.js
@@ -50,7 +50,6 @@ describe('otoroshi commands', function () {
     expect(response.initialCredentials.user).to.be.a('string');
     expect(response.initialCredentials.password).to.be.a('string');
     expect(response.features).to.be.an('object');
-    expect(response.environment).to.be.an('array');
   });
 
   it('should reboot otoroshi', async () => {
@@ -103,7 +102,6 @@ describe('otoroshi commands', function () {
 
     expect(response.id).to.equal(addon.realId);
     expect(response.version).to.be.a('string');
-    expect(response.environment).to.be.an('array');
   });
 
   it('should create otoroshi network group', async () => {

--- a/test/unit/lib/request/request.spec.js
+++ b/test/unit/lib/request/request.spec.js
@@ -449,6 +449,60 @@ describe('request', () => {
       expect(spy.callCount).to.equal(0);
       expect(response2.body).to.deep.equal(newResponseBody);
     });
+
+    it('should NOT share cache between different query params', async () => {
+      const responseBody = { data: 'response' };
+      await apiMockCtrl.mock().when({ method: 'GET', path: '/api/test' }).respond({ status: 200, body: responseBody });
+
+      const spy = hanbi.spyMethod(globalThis, 'fetch').passThrough();
+
+      const result1 = await sendRequest({
+        method: 'GET',
+        url: `/api/test`,
+        headers: new HeadersBuilder().acceptJson().build(),
+        queryParams: new QueryParams().set('page', 'a'),
+        cache: { ttl: 1000 },
+      });
+
+      const result2 = await sendRequest({
+        method: 'GET',
+        url: `/api/test`,
+        headers: new HeadersBuilder().acceptJson().build(),
+        queryParams: new QueryParams().set('page', 'b'),
+        cache: { ttl: 1000 },
+      });
+
+      // Each unique query param set should hit the network independently
+      expect(spy.callCount).to.equal(2);
+      expect(result1.body).to.deep.equal(responseBody);
+      expect(result2.body).to.deep.equal(responseBody);
+    });
+
+    it('should share cache for same query params', async () => {
+      const responseBody = { data: 'cached' };
+      await apiMockCtrl.mock().when({ method: 'GET', path: '/api/test' }).respond({ status: 200, body: responseBody });
+
+      await sendRequest({
+        method: 'GET',
+        url: `/api/test`,
+        headers: new HeadersBuilder().acceptJson().build(),
+        queryParams: new QueryParams().set('page', '1'),
+        cache: { ttl: 1000 },
+      });
+
+      const spy = hanbi.spyMethod(globalThis, 'fetch').passThrough();
+
+      const response = await sendRequest({
+        method: 'GET',
+        url: `/api/test`,
+        headers: new HeadersBuilder().acceptJson().build(),
+        queryParams: new QueryParams().set('page', '1'),
+        cache: { ttl: 1000 },
+      });
+
+      expect(spy.callCount).to.equal(0);
+      expect(response.body).to.deep.equal(responseBody);
+    });
   });
 
   describe('dedupe', () => {
@@ -500,6 +554,39 @@ describe('request', () => {
       const result2 = await sendRequest({ url: '/api/test' });
 
       expect(spy.callCount).to.equal(2);
+      expect(result1.body).to.deep.equal(responseBody);
+      expect(result2.body).to.deep.equal(responseBody);
+    });
+
+    it('concurrent requests with different query params should make separate fetch calls', async () => {
+      const responseBody = { data: 'response' };
+      await apiMockCtrl.mock().when({ method: 'GET', path: '/api/test' }).respond({ status: 200, body: responseBody });
+
+      const spy = hanbi.spyMethod(globalThis, 'fetch').passThrough();
+
+      const [result1, result2] = await Promise.all([
+        sendRequest({ url: '/api/test', queryParams: new QueryParams().set('page', 'a') }),
+        sendRequest({ url: '/api/test', queryParams: new QueryParams().set('page', 'b') }),
+      ]);
+
+      // Different query params should NOT be deduplicated together
+      expect(spy.callCount).to.equal(2);
+      expect(result1.body).to.deep.equal(responseBody);
+      expect(result2.body).to.deep.equal(responseBody);
+    });
+
+    it('concurrent requests with same query params should be deduplicated to a single fetch', async () => {
+      const responseBody = { data: 'deduped' };
+      await apiMockCtrl.mock().when({ method: 'GET', path: '/api/test' }).respond({ status: 200, body: responseBody });
+
+      const spy = hanbi.spyMethod(globalThis, 'fetch').passThrough();
+
+      const [result1, result2] = await Promise.all([
+        sendRequest({ url: '/api/test', queryParams: new QueryParams().set('page', '1') }),
+        sendRequest({ url: '/api/test', queryParams: new QueryParams().set('page', '1') }),
+      ]);
+
+      expect(spy.callCount).to.equal(1);
       expect(result1.body).to.deep.equal(responseBody);
       expect(result2.body).to.deep.equal(responseBody);
     });

--- a/test/unit/lib/request/request.spec.js
+++ b/test/unit/lib/request/request.spec.js
@@ -451,6 +451,60 @@ describe('request', () => {
     });
   });
 
+  describe('dedupe', () => {
+    it('concurrent same request should make only 1 fetch call', async () => {
+      const responseBody = { data: 'test response' };
+      await apiMockCtrl.mock().when({ method: 'GET', path: '/api/test' }).respond({ status: 200, body: responseBody });
+
+      const spy = hanbi.spyMethod(globalThis, 'fetch').passThrough();
+
+      const [result1, result2] = await Promise.all([
+        sendRequest({ url: '/api/test' }),
+        sendRequest({ url: '/api/test' }),
+      ]);
+
+      expect(spy.callCount).to.equal(1);
+      expect(result1.body).to.deep.equal(responseBody);
+      expect(result2.body).to.deep.equal(responseBody);
+    });
+
+    it('concurrent different requests should make 2 fetch calls', async () => {
+      const response1Body = { data: 'response 1' };
+      const response2Body = { data: 'response 2' };
+      await apiMockCtrl
+        .mock()
+        .when({ method: 'GET', path: '/api/test1' })
+        .respond({ status: 200, body: response1Body })
+        .when({ method: 'GET', path: '/api/test2' })
+        .respond({ status: 200, body: response2Body });
+
+      const spy = hanbi.spyMethod(globalThis, 'fetch').passThrough();
+
+      const [result1, result2] = await Promise.all([
+        sendRequest({ url: '/api/test1' }),
+        sendRequest({ url: '/api/test2' }),
+      ]);
+
+      expect(spy.callCount).to.equal(2);
+      expect(result1.body).to.deep.equal(response1Body);
+      expect(result2.body).to.deep.equal(response2Body);
+    });
+
+    it('sequential same request should make 2 fetch calls (dedupe only applies while pending)', async () => {
+      const responseBody = { data: 'test response' };
+      await apiMockCtrl.mock().when({ method: 'GET', path: '/api/test' }).respond({ status: 200, body: responseBody });
+
+      const spy = hanbi.spyMethod(globalThis, 'fetch').passThrough();
+
+      const result1 = await sendRequest({ url: '/api/test' });
+      const result2 = await sendRequest({ url: '/api/test' });
+
+      expect(spy.callCount).to.equal(2);
+      expect(result1.body).to.deep.equal(responseBody);
+      expect(result2.body).to.deep.equal(responseBody);
+    });
+  });
+
   describe('timeout', () => {
     it('should timeout', async function () {
       this.timeout(50);


### PR DESCRIPTION
## What does this PR do?

- Adds a new `request-with-dedupe` Request Wrapper and `dedupe` feature,
  - This new feature makes the client reuse the same promise when trying to fetch something that is already pending (for instance two components try to fetch info about the same add-on roughly at the same time).
- Moves `caculateCacheKey` to `utils.js` so it can be used by both cache and dedupe request wrappers,
- Fixes query params retrieval for cache key calculation,
- Removes `environment` and adds `api.swaggerUrl` to Otoroshi types to match the updated API payloads.

## How to review?

- Check the commits,
- [x] Checked that dedupe and all dashboard screens work with this version of the new client.