### PR TITLE
feat(metrics): migrate stats commands to the Warp10 v4 stats API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2369,7 +2369,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.12.tgz",
       "integrity": "sha512-r7wNXakLeSsGT0H1AU863vS2wa5wBOK4bWMjZz2wj+8nBx+m5PeIn0k8AloSLpRuiwdRQZwarZqHE4FNArPuJQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -3083,7 +3082,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4132,7 +4130,6 @@
       "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -4417,8 +4414,7 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1464554.tgz",
       "integrity": "sha512-CAoP3lYfwAGQTaAXYvA6JZR0fjGUb7qec1qf4mToyoH2TZgUFeIqYcjh6f9jNuhHfuZiEdH+PONHYrLhRQX6aw==",
       "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/diff": {
       "version": "5.0.0",
@@ -4752,7 +4748,6 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4868,6 +4863,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "debug": "^3.2.7",
         "is-core-module": "^2.13.0",
@@ -4881,6 +4877,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "ms": "^2.1.1"
       }
@@ -5337,6 +5334,7 @@
       "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.3.tgz",
       "integrity": "sha512-nVpZkTMM9rF6AQ9gPJpFsNAMt48wIzB5TQgiTLdHiuO8XEDhUgZEhqKlZWXbIzo9VmJ/HvysHqEaVeD5v9TPvA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       }
@@ -6880,7 +6878,6 @@
       "resolved": "https://registry.npmjs.org/koa/-/koa-2.15.3.tgz",
       "integrity": "sha512-j/8tY9j5t+GVMLeioLaxweJiKUayFhlGqNTzf2ZGwL0ZCQijd2RLHK0SLW5Tsko8YyyqCZC2cojIb0/s62qTAg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "accepts": "^1.3.5",
         "cache-content-type": "^1.0.0",
@@ -8285,7 +8282,6 @@
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -8709,7 +8705,6 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.19.0.tgz",
       "integrity": "sha512-5r7EYSQIowHsK4eTZ0Y81qpZuJz+MUuYeqmmYmRMl1nwhdmbiYqt5jwzf6u7wyOzJgYqtCRMtVRKOtHANBz7rA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.5"
       },
@@ -9342,7 +9337,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9506,7 +9500,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9578,7 +9571,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "napi-postinstall": "^0.3.0"
       },

--- a/src/clients/cc-api/commands/metrics/get-heat-map-command.js
+++ b/src/clients/cc-api/commands/metrics/get-heat-map-command.js
@@ -1,0 +1,47 @@
+/**
+ * @import { GetHeatMapCommandInput, GetHeatMapCommandOutput } from './get-heat-map-command.types.js';
+ */
+import { QueryParams } from '../../../../lib/request/query-params.js';
+import { get } from '../../../../lib/request/request-params-builder.js';
+import { normalizeDate, safeUrl } from '../../../../lib/utils.js';
+import { CcApiSimpleCommand } from '../../lib/cc-api-command.js';
+
+/**
+ * Gets the geographic heat map of incoming requests for an owner, optionally restricted to a single application.
+ * Each point aggregates the number of requests originating from a geographic cell over the time range.
+ *
+ * @extends {CcApiSimpleCommand<GetHeatMapCommandInput, GetHeatMapCommandOutput>}
+ * @endpoint [GET] /v4/stats/organisations/:XXX/requests
+ * @group Metrics
+ * @version 4
+ */
+export class GetHeatMapCommand extends CcApiSimpleCommand {
+  /** @type {CcApiSimpleCommand<GetHeatMapCommandInput, GetHeatMapCommandOutput>['toRequestParams']} */
+  toRequestParams(params) {
+    return get(
+      safeUrl`/v4/stats/organisations/${params.ownerId}/requests`,
+      new QueryParams()
+        .set('applicationId', params.applicationId)
+        .set('from', normalizeDate(params.from))
+        .set('to', normalizeDate(params.to)),
+    );
+  }
+
+  /** @type {CcApiSimpleCommand<GetHeatMapCommandInput, GetHeatMapCommandOutput>['transformCommandOutput']} */
+  transformCommandOutput(response) {
+    return (response ?? []).map(
+      /** @param {{long: number, lat: number, accessCount: number}} point */ ({ long, lat, accessCount }) => ({
+        lat,
+        lon: long,
+        count: accessCount,
+      }),
+    );
+  }
+
+  /** @type {CcApiSimpleCommand<?, ?>['getIdsToResolve']} */
+  getIdsToResolve() {
+    return {
+      ownerId: true,
+    };
+  }
+}

--- a/src/clients/cc-api/commands/metrics/get-heat-map-command.types.d.ts
+++ b/src/clients/cc-api/commands/metrics/get-heat-map-command.types.d.ts
@@ -1,0 +1,24 @@
+import type { MaybeWithOwnerId } from '../../types/cc-api.types.js';
+
+export type GetHeatMapCommandInput = MaybeWithOwnerId<{
+  /**
+   * Restrict the heat map to a single application.
+   * When omitted, the heat map covers every application of the owner.
+   */
+  applicationId?: string;
+  /** Start of the time range. */
+  from?: Date | string | number;
+  /** End of the time range. */
+  to?: Date | string | number;
+}>;
+
+export type GetHeatMapCommandOutput = Array<HeatMapPoint>;
+
+export interface HeatMapPoint {
+  /** Latitude of the geographic cell the requests were aggregated into. */
+  lat: number;
+  /** Longitude of the geographic cell the requests were aggregated into. */
+  lon: number;
+  /** Number of requests originating from this geographic cell over the time range. */
+  count: number;
+}

--- a/src/clients/cc-api/commands/metrics/get-metrics-command.js
+++ b/src/clients/cc-api/commands/metrics/get-metrics-command.js
@@ -7,6 +7,8 @@ import { get } from '../../../../lib/request/request-params-builder.js';
 import { normalizeDate, safeUrl } from '../../../../lib/utils.js';
 import { CcApiSimpleCommand } from '../../lib/cc-api-command.js';
 
+const MICROSECONDS_PER_MILLISECOND = 1000;
+
 /**
  *
  * @extends {CcApiSimpleCommand<GetMetricsCommandInput, GetMetricsCommandOutput>}
@@ -32,12 +34,17 @@ export class GetMetricsCommand extends CcApiSimpleCommand {
 
   /** @type {CcApiSimpleCommand<GetMetricsCommandInput, GetMetricsCommandOutput>['transformCommandOutput']} */
   transformCommandOutput(response) {
+    const toMilliseconds = this.params.timestampUnit == null || this.params.timestampUnit === 'ms';
+
     /** @type {GetMetricsCommandOutput} */
     const result = {};
 
     response.forEach(
       /** @param {{name: MetricKind, data: Array<MetricData>}} metric */ ({ name, data }) => {
-        result[name] = data.map(({ timestamp, value }) => ({ timestamp, value: Number(value) }));
+        result[name] = data.map(({ timestamp, value }) => ({
+          timestamp: toMilliseconds ? Math.round(timestamp / MICROSECONDS_PER_MILLISECOND) : timestamp,
+          value: Number(value),
+        }));
       },
     );
 

--- a/src/clients/cc-api/commands/metrics/get-metrics-command.types.d.ts
+++ b/src/clients/cc-api/commands/metrics/get-metrics-command.types.d.ts
@@ -7,6 +7,11 @@ export type GetMetricsCommandInput = ApplicationOrAddonId & {
   span?: string;
   end?: Date | string | number;
   fill?: boolean;
+  /**
+   * Unit of the `timestamp` field in the result.
+   * @default 'ms'
+   */
+  timestampUnit?: 'us' | 'ms';
 };
 
 export type GetMetricsCommandOutput = Metrics;

--- a/src/clients/cc-api/commands/metrics/get-status-code-distribution-command.js
+++ b/src/clients/cc-api/commands/metrics/get-status-code-distribution-command.js
@@ -1,0 +1,79 @@
+/**
+ * @import { GetStatusCodeDistributionCommandInput, GetStatusCodeDistributionCommandOutput } from './get-status-code-distribution-command.types.js';
+ */
+import { QueryParams } from '../../../../lib/request/query-params.js';
+import { get } from '../../../../lib/request/request-params-builder.js';
+import { normalizeDate, safeUrl } from '../../../../lib/utils.js';
+import { CcApiSimpleCommand } from '../../lib/cc-api-command.js';
+
+/** Lowest valid HTTP status code. Codes below this are non-standard. */
+const MIN_STANDARD_STATUS_CODE = 100;
+
+/**
+ * Gets the distribution of HTTP status codes over time for an owner, optionally restricted to a single application.
+ *
+ * @extends {CcApiSimpleCommand<GetStatusCodeDistributionCommandInput, GetStatusCodeDistributionCommandOutput>}
+ * @endpoint [GET] /v4/stats/organisations/:XXX/http-status-codes
+ * @group Metrics
+ * @version 4
+ */
+export class GetStatusCodeDistributionCommand extends CcApiSimpleCommand {
+  /** @type {CcApiSimpleCommand<GetStatusCodeDistributionCommandInput, GetStatusCodeDistributionCommandOutput>['toRequestParams']} */
+  toRequestParams(params) {
+    return get(
+      safeUrl`/v4/stats/organisations/${params.ownerId}/http-status-codes`,
+      new QueryParams()
+        .set('applicationId', params.applicationId)
+        .set('from', normalizeDate(params.from))
+        .set('to', normalizeDate(params.to)),
+    );
+  }
+
+  /** @type {CcApiSimpleCommand<GetStatusCodeDistributionCommandInput, GetStatusCodeDistributionCommandOutput>['transformCommandOutput']} */
+  transformCommandOutput(response) {
+    const excludeNonStandard = this.params.excludeNonStandardStatusCodes === true;
+
+    /**
+     * @param {Array<{code: number, count: number}>} [statuses]
+     * @returns {Array<{code: number, count: number}>}
+     */
+    const keep = (statuses) =>
+      (statuses ?? []).filter(({ code }) => !excludeNonStandard || code >= MIN_STANDARD_STATUS_CODE);
+
+    const byDate = response.map(
+      /** @param {{date: string, statuses?: Array<{code: number, count: number}>}} entry */ ({ date, statuses }) => {
+        const kept = keep(statuses);
+        return {
+          date: normalizeDate(date),
+          total: kept.reduce((sum, { count }) => sum + count, 0),
+          statuses: Object.fromEntries(kept.map(({ code, count }) => [code, count])),
+        };
+      },
+    );
+
+    /** @type {Record<number, number>} */
+    const statuses = {};
+    response.forEach(
+      /** @param {{statuses?: Array<{code: number, count: number}>}} entry */ ({ statuses: entryStatuses }) => {
+        keep(entryStatuses).forEach(({ code, count }) => {
+          statuses[code] = (statuses[code] ?? 0) + count;
+        });
+      },
+    );
+
+    return {
+      byDate,
+      byStatusCode: {
+        total: Object.values(statuses).reduce((sum, count) => sum + count, 0),
+        statuses,
+      },
+    };
+  }
+
+  /** @type {CcApiSimpleCommand<?, ?>['getIdsToResolve']} */
+  getIdsToResolve() {
+    return {
+      ownerId: true,
+    };
+  }
+}

--- a/src/clients/cc-api/commands/metrics/get-status-code-distribution-command.types.d.ts
+++ b/src/clients/cc-api/commands/metrics/get-status-code-distribution-command.types.d.ts
@@ -1,0 +1,38 @@
+import type { MaybeWithOwnerId } from '../../types/cc-api.types.js';
+
+export type GetStatusCodeDistributionCommandInput = MaybeWithOwnerId<{
+  /**
+   * Restrict the distribution to a single application.
+   * When omitted, the distribution covers every application of the owner.
+   */
+  applicationId?: string;
+  /** Start of the time range. */
+  from?: Date | string | number;
+  /** End of the time range. */
+  to?: Date | string | number;
+  /**
+   * Drop non-standard status codes (lower than 100) from the result.
+   * Totals are recomputed over the remaining status codes.
+   * @default false
+   */
+  excludeNonStandardStatusCodes?: boolean;
+}>;
+
+export interface GetStatusCodeDistributionCommandOutput {
+  /** Distribution per time bucket. */
+  byDate: Array<StatusCodeDistributionByDate>;
+  /** Distribution aggregated over the whole period, keyed by HTTP status code. */
+  byStatusCode: StatusCodeCounts;
+}
+
+export interface StatusCodeCounts {
+  /** Total number of requests across all status codes. */
+  total: number;
+  /** Request count keyed by HTTP status code. */
+  statuses: Record<number, number>;
+}
+
+export interface StatusCodeDistributionByDate extends StatusCodeCounts {
+  /** Date of the time bucket, as an ISO 8601 string. */
+  date: string;
+}

--- a/src/clients/cc-api/commands/metrics/stream-requests-command.js
+++ b/src/clients/cc-api/commands/metrics/stream-requests-command.js
@@ -1,0 +1,57 @@
+/**
+ * @import { StreamRequestsCommandInput, RequestLocation } from './stream-requests-command.types.js'
+ */
+import { QueryParams } from '../../../../lib/request/query-params.js';
+import { CcStream } from '../../../../lib/stream/cc-stream.js';
+import { safeUrl } from '../../../../lib/utils.js';
+import { CcApiStreamCommand } from '../../lib/cc-api-command.js';
+
+/**
+ * Streams live request locations for an owner, optionally restricted to a single application.
+ * Each emitted batch aggregates the incoming requests by geographic cell over a short time window.
+ *
+ * @extends {CcApiStreamCommand<StreamRequestsCommandInput, RequestsStream>}
+ * @endpoint [GET] /v4/stats/organisations/:XXX/requests-live
+ * @group Metrics
+ * @version 4
+ */
+export class StreamRequestsCommand extends CcApiStreamCommand {
+  /** @type {CcApiStreamCommand<StreamRequestsCommandInput, RequestsStream>['toRequestParams']} */
+  toRequestParams(params) {
+    return {
+      url: safeUrl`/v4/stats/organisations/${params.ownerId}/requests-live`,
+      queryParams: new QueryParams().set('applicationId', params.applicationId),
+    };
+  }
+
+  /** @type {CcApiStreamCommand<StreamRequestsCommandInput, RequestsStream>['createStream']} */
+  createStream(requestFactory, config) {
+    return new RequestsStream(requestFactory, config);
+  }
+
+  /** @type {CcApiStreamCommand<?, ?>['getIdsToResolve']} */
+  getIdsToResolve() {
+    return {
+      ownerId: true,
+    };
+  }
+}
+
+/**
+ * SSE stream of live request locations aggregated by geographic cell.
+ */
+export class RequestsStream extends CcStream {
+  /**
+   * Registers a callback invoked with each batch of aggregated request locations.
+   *
+   * @param {(locations: Array<RequestLocation>) => void} callback The function which handles a batch of request locations
+   * @returns {this}
+   */
+  onRequests(callback) {
+    return this.on('REQUESTS_LIVE', (event) => {
+      /** @type {Array<{ long: number, lat: number, city: string, accessCount: number }>} */
+      const payload = JSON.parse(event.data);
+      callback(payload.map(({ long, lat, city, accessCount }) => ({ lat, lon: long, city, count: accessCount })));
+    });
+  }
+}

--- a/src/clients/cc-api/commands/metrics/stream-requests-command.types.d.ts
+++ b/src/clients/cc-api/commands/metrics/stream-requests-command.types.d.ts
@@ -1,0 +1,20 @@
+import type { MaybeWithOwnerId } from '../../types/cc-api.types.js';
+
+export type StreamRequestsCommandInput = MaybeWithOwnerId<{
+  /**
+   * Restrict the stream to a single application.
+   * When omitted, the stream covers every application of the owner.
+   */
+  applicationId?: string;
+}>;
+
+export interface RequestLocation {
+  /** Latitude of the geographic cell the requests were aggregated into. */
+  lat: number;
+  /** Longitude of the geographic cell the requests were aggregated into. */
+  lon: number;
+  /** Most frequent city among the requests aggregated into this geographic cell. */
+  city: string;
+  /** Number of requests originating from this geographic cell during the batch window. */
+  count: number;
+}

--- a/src/clients/cc-api/commands/warp-token/get-warp-token-command.js
+++ b/src/clients/cc-api/commands/warp-token/get-warp-token-command.js
@@ -1,24 +1,52 @@
 /**
  * @import { GetWarpTokenCommandInput, GetWarpTokenCommandOutput } from './get-warp-token-command.types.js';
  */
-import { get } from '../../../../lib/request/request-params-builder.js';
-import { safeUrl } from '../../../../lib/utils.js';
+import { post } from '../../../../lib/request/request-params-builder.js';
+import { normalizeDate, safeUrl } from '../../../../lib/utils.js';
 import { CcApiSimpleCommand } from '../../lib/cc-api-command.js';
 
 /**
  *
  * @extends {CcApiSimpleCommand<GetWarpTokenCommandInput, GetWarpTokenCommandOutput>}
- * @endpoint [GET] /v2/metrics/read/:XXX
- * @endpoint [GET] /v2/w10tokens/accessLogs/read/:XXX
+ * @endpoint [POST] /v4/stats/organisations/{ownerId}/tokens/read
+ * @endpoint [POST] /v4/stats/organisations/{ownerId}/resources/{resourceId}/tokens/read
  * @group WarpToken
- * @version 2
+ * @version 4
  */
 export class GetWarpTokenCommand extends CcApiSimpleCommand {
   /** @type {CcApiSimpleCommand<GetWarpTokenCommandInput, GetWarpTokenCommandOutput>['toRequestParams']} */
   toRequestParams(params) {
-    if (params.tokenKind === 'METRICS') {
-      return get(safeUrl`/v2/metrics/read/${params.ownerId}`);
+    const url =
+      'applicationId' in params && params.applicationId != null && params.applicationId !== ''
+        ? safeUrl`/v4/stats/organisations/${params.ownerId}/resources/${params.applicationId}/tokens/read`
+        : safeUrl`/v4/stats/organisations/${params.ownerId}/tokens/read`;
+
+    const body = {};
+    if (params.applications != null && params.applications.length > 0) {
+      body.applications = params.applications;
     }
-    return get(safeUrl`/v2/w10tokens/accessLogs/read/${params.ownerId}`);
+    if (params.ttl != null) {
+      body.ttl = params.ttl;
+    }
+
+    return post(url, body);
+  }
+
+  /** @type {CcApiSimpleCommand<GetWarpTokenCommandInput, GetWarpTokenCommandOutput>['transformCommandOutput']} */
+  transformCommandOutput(response) {
+    return {
+      token: response.token,
+      expiresAt: normalizeDate(response.expiresAt),
+      createdAt: normalizeDate(response.createdAt),
+      scope: response.scope,
+      applications: response.applications,
+    };
+  }
+
+  /** @type {CcApiSimpleCommand<?, ?>['getIdsToResolve']} */
+  getIdsToResolve() {
+    return {
+      ownerId: true,
+    };
   }
 }

--- a/src/clients/cc-api/commands/warp-token/get-warp-token-command.types.d.ts
+++ b/src/clients/cc-api/commands/warp-token/get-warp-token-command.types.d.ts
@@ -1,6 +1,25 @@
-export interface GetWarpTokenCommandInput {
+export type GetWarpTokenCommandInput = GetWarpTokenCommandInputOwner | GetWarpTokenCommandInputResource;
+
+export interface GetWarpTokenCommandInputOwner extends GetWarpTokenCommandInputBase {
   ownerId: string;
-  tokenKind: 'METRICS' | 'ACCESS_LOGS';
 }
 
-export type GetWarpTokenCommandOutput = string;
+export interface GetWarpTokenCommandInputResource extends GetWarpTokenCommandInputBase {
+  ownerId?: string;
+  applicationId: string;
+}
+
+export interface GetWarpTokenCommandInputBase {
+  applications?: Array<WarpTokenApplication>;
+  ttl?: string;
+}
+
+export type WarpTokenApplication = 'metrics' | 'metrics.accesslogs' | 'addon-api-cellar';
+
+export interface GetWarpTokenCommandOutput {
+  token: string;
+  expiresAt: string;
+  createdAt: string;
+  scope: 'READ';
+  applications: Array<WarpTokenApplication>;
+}

--- a/test/e2e/clients/cc-api/commands/metrics-commands.spec.js
+++ b/test/e2e/clients/cc-api/commands/metrics-commands.spec.js
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import { GetHeatMapCommand } from '../../../../../src/clients/cc-api/commands/metrics/get-heat-map-command.js';
 import { GetMetricsCommand } from '../../../../../src/clients/cc-api/commands/metrics/get-metrics-command.js';
 import { GetStatusCodeDistributionCommand } from '../../../../../src/clients/cc-api/commands/metrics/get-status-code-distribution-command.js';
 import { checkDateFormat } from '../../../../lib/expect-utils.js';
@@ -52,6 +53,17 @@ describe('metrics commands', function () {
     Object.entries(response.byStatusCode.statuses).forEach(([code, count]) => {
       expect(Number(code)).to.be.a('number');
       expect(count).to.be.a('number');
+    });
+  });
+
+  it('should get application requests heat map', async () => {
+    const response = await support.client.send(new GetHeatMapCommand({ applicationId: STATIC_LOGS_APPLICATION }));
+
+    expect(response).to.be.an('array');
+    response.forEach((point) => {
+      expect(point.lat).to.be.a('number');
+      expect(point.lon).to.be.a('number');
+      expect(point.count).to.be.a('number');
     });
   });
 });

--- a/test/e2e/clients/cc-api/commands/metrics-commands.spec.js
+++ b/test/e2e/clients/cc-api/commands/metrics-commands.spec.js
@@ -1,7 +1,13 @@
+/**
+ * @import { RequestLocation } from '../../../../../src/clients/cc-api/commands/metrics/stream-requests-command.types.js';
+ * @import { CcStream } from '../../../../../src/lib/stream/cc-stream.js';
+ */
 import { expect } from 'chai';
 import { GetHeatMapCommand } from '../../../../../src/clients/cc-api/commands/metrics/get-heat-map-command.js';
 import { GetMetricsCommand } from '../../../../../src/clients/cc-api/commands/metrics/get-metrics-command.js';
 import { GetStatusCodeDistributionCommand } from '../../../../../src/clients/cc-api/commands/metrics/get-status-code-distribution-command.js';
+import { StreamRequestsCommand } from '../../../../../src/clients/cc-api/commands/metrics/stream-requests-command.js';
+import { Deferred } from '../../../../../src/lib/utils.js';
 import { checkDateFormat } from '../../../../lib/expect-utils.js';
 import { e2eSupport, STATIC_LOGS_APPLICATION, STATIC_MYSQL_ADDON_ID } from '../e2e-support.js';
 
@@ -64,6 +70,45 @@ describe('metrics commands', function () {
       expect(point.lat).to.be.a('number');
       expect(point.lon).to.be.a('number');
       expect(point.count).to.be.a('number');
+    });
+  });
+
+  describe('requests live stream', function () {
+    /** @type {CcStream} */
+    let currentStream = null;
+
+    afterEach(async () => {
+      currentStream?.close();
+    });
+
+    it('should stream live request locations', async () => {
+      /** @type {Deferred<Array<RequestLocation>>} */
+      const deferred = new Deferred();
+
+      currentStream = (
+        await support.client.stream(new StreamRequestsCommand({ applicationId: STATIC_LOGS_APPLICATION }))
+      )
+        .onOpen(() => {
+          // this API call will trigger a request that gets aggregated into a live location
+          fetch(`https://${STATIC_LOGS_APPLICATION.replaceAll('_', '-')}.cleverapps.io`, { method: 'GET' });
+        })
+        .onRequests((locations) => {
+          if (locations.length > 0) {
+            deferred.resolve(locations);
+          }
+        })
+        .onError(deferred.reject);
+
+      currentStream.start();
+      const locations = await deferred.promise;
+
+      expect(locations).to.be.an('array');
+      locations.forEach((location) => {
+        expect(location.lat).to.be.a('number');
+        expect(location.lon).to.be.a('number');
+        expect(location.city).to.be.a('string');
+        expect(location.count).to.be.a('number');
+      });
     });
   });
 });

--- a/test/e2e/clients/cc-api/commands/metrics-commands.spec.js
+++ b/test/e2e/clients/cc-api/commands/metrics-commands.spec.js
@@ -1,6 +1,8 @@
 import { expect } from 'chai';
 import { GetMetricsCommand } from '../../../../../src/clients/cc-api/commands/metrics/get-metrics-command.js';
-import { e2eSupport, STATIC_MYSQL_ADDON_ID } from '../e2e-support.js';
+import { GetStatusCodeDistributionCommand } from '../../../../../src/clients/cc-api/commands/metrics/get-status-code-distribution-command.js';
+import { checkDateFormat } from '../../../../lib/expect-utils.js';
+import { e2eSupport, STATIC_LOGS_APPLICATION, STATIC_MYSQL_ADDON_ID } from '../e2e-support.js';
 
 describe('metrics commands', function () {
   const support = e2eSupport({ user: 'test-user-without-github' });
@@ -27,5 +29,29 @@ describe('metrics commands', function () {
     expect(response.load1).to.be.an('array');
     expect(response.load1[0].timestamp).to.be.a('number');
     expect(response.load1[0].value).to.be.a('number');
+  });
+
+  it('should get application status code distribution', async () => {
+    const response = await support.client.send(
+      new GetStatusCodeDistributionCommand({ applicationId: STATIC_LOGS_APPLICATION }),
+    );
+
+    expect(response.byDate).to.be.an('array');
+    response.byDate.forEach((entry) => {
+      checkDateFormat(entry.date);
+      expect(entry.total).to.be.a('number');
+      expect(entry.statuses).to.be.an('object');
+      Object.entries(entry.statuses).forEach(([code, count]) => {
+        expect(Number(code)).to.be.a('number');
+        expect(count).to.be.a('number');
+      });
+    });
+
+    expect(response.byStatusCode.total).to.be.a('number');
+    expect(response.byStatusCode.statuses).to.be.an('object');
+    Object.entries(response.byStatusCode.statuses).forEach(([code, count]) => {
+      expect(Number(code)).to.be.a('number');
+      expect(count).to.be.a('number');
+    });
   });
 });

--- a/test/e2e/clients/cc-api/commands/warp-token-commands.spec.js
+++ b/test/e2e/clients/cc-api/commands/warp-token-commands.spec.js
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import { GetWarpTokenCommand } from '../../../../../src/clients/cc-api/commands/warp-token/get-warp-token-command.js';
+import { checkDateFormat } from '../../../../lib/expect-utils.js';
 import { e2eSupport } from '../e2e-support.js';
 
 describe('warp token commands', function () {
@@ -17,21 +18,65 @@ describe('warp token commands', function () {
     const response = await support.client.send(
       new GetWarpTokenCommand({
         ownerId: support.organisationId,
-        tokenKind: 'METRICS',
+        applications: ['metrics'],
+        ttl: 'P5D',
       }),
     );
 
-    expect(response).to.be.a('string');
+    expect(response.token).to.be.a('string');
+    checkDateFormat(response.expiresAt);
+    checkDateFormat(response.createdAt);
+    expect(response.scope).to.be.equal('READ');
+    expect(response.applications).to.deep.equalInAnyOrder(['metrics']);
   });
 
   it('should get access logs token', async () => {
     const response = await support.client.send(
       new GetWarpTokenCommand({
         ownerId: support.organisationId,
-        tokenKind: 'ACCESS_LOGS',
+        applications: ['metrics.accesslogs'],
+        ttl: 'P5D',
       }),
     );
 
-    expect(response).to.be.a('string');
+    expect(response.token).to.be.a('string');
+    checkDateFormat(response.expiresAt);
+    checkDateFormat(response.createdAt);
+    expect(response.scope).to.be.equal('READ');
+    expect(response.applications).to.deep.equalInAnyOrder(['metrics.accesslogs']);
+  });
+
+  it('should get metrics token for application', async () => {
+    const application = await support.createTestApplication();
+    const response = await support.client.send(
+      new GetWarpTokenCommand({
+        applicationId: application.id,
+        applications: ['metrics'],
+        ttl: 'P5D',
+      }),
+    );
+
+    expect(response.token).to.be.a('string');
+    checkDateFormat(response.expiresAt);
+    checkDateFormat(response.createdAt);
+    expect(response.scope).to.be.equal('READ');
+    expect(response.applications).to.deep.equalInAnyOrder(['metrics']);
+  });
+
+  it('should get access logs token for application', async () => {
+    const application = await support.createTestApplication();
+    const response = await support.client.send(
+      new GetWarpTokenCommand({
+        applicationId: application.id,
+        applications: ['metrics.accesslogs'],
+        ttl: 'P5D',
+      }),
+    );
+
+    expect(response.token).to.be.a('string');
+    checkDateFormat(response.expiresAt);
+    checkDateFormat(response.createdAt);
+    expect(response.scope).to.be.equal('READ');
+    expect(response.applications).to.deep.equalInAnyOrder(['metrics.accesslogs']);
   });
 });


### PR DESCRIPTION
## Context

The legacy Warp10 v2 read endpoints (`/v2/metrics/read`, `/v2/w10tokens/...`) are being
retired in favour of the v4 stats API. The v4 API issues scoped, time-limited read tokens,
can target a single application resource rather than only the whole organisation, and
exposes new aggregates (geographic request distribution, HTTP status code distribution)
that the v2 endpoints never offered. This PR moves the client onto v4 and surfaces those
new aggregates as first-class commands.

## Changes

- **Migrate `GetWarpTokenCommand` to the v4 stats tokens API.** It now POSTs to
  `/v4/stats/organisations/:id/tokens/read` (or the `/resources/:appId/...` variant when an
  `applicationId` is given) and returns a structured token object instead of a bare string.
- **Add `GetStatusCodeDistributionCommand`** over `/v4/stats/.../http-status-codes`, returning
  both a per-date breakdown and a period-wide aggregate, with an opt-in flag to drop
  non-standard (<100) codes and recompute the totals.
- **Add `GetHeatMapCommand`** over `/v4/stats/.../requests`, returning the geographic
  distribution of incoming requests as `{lat, lon, count}` points.
- **Add `StreamRequestsCommand`** over `/v4/stats/.../requests-live`, an SSE stream that
  emits the same geo-cell aggregation live as traffic comes in. Pairs with the heat map:
  heat map for history, stream for a real-time map.
- **Add an opt-in `timestampUnit: 'ms'` to `GetMetricsCommand`** so consumers can get
  millisecond timestamps instead of the API's raw microseconds.

### Implementation notes

- **Breaking change in `GetWarpTokenCommand`.** The input drops `tokenKind` in favour of
  optional `applications` + `ttl` (and an optional `applicationId` to scope the token), and
  the output changes from a `string` to `{ token, scope, expiresAt, createdAt, applications }`.
  Any caller reading the old bare-string token must be updated.
- Outputs are reshaped to insulate consumers from the API's field names: the heat map and
  the live stream both map `long`/`accessCount` to `lon`/`count` so points drop straight
  into mapping libraries.
- `timestampUnit` defaults to `'us'` (raw microseconds) so existing `GetMetricsCommand`
  callers see no behaviour change.

## How to review

1. Start with `get-warp-token-command.js` / `.types.d.ts` — it carries the breaking change
   and the v2 -> v4 shift; the other v4 commands follow the same shape.
2. Read the new commands' `transformCommandOutput` / stream handler (heat map reshaping,
   status-code filtering + total recomputation, `stream-requests-command.js` reusing
   `CcStream`) and check the type definitions match.
3. Run `npm run test:unit` — the `metrics-commands.spec.js` and `warp-token-commands.spec.js`
   suites cover the new endpoints, the `timestampUnit` conversion, the non-standard-code
   exclusion, and the live-requests SSE stream.

**1 approval.**