### PR TITLE
fix(network-group): normalize `member.kind` field

### DIFF
--- a/src/clients/cc-api/commands/network-group/get-network-group-command.js
+++ b/src/clients/cc-api/commands/network-group/get-network-group-command.js
@@ -4,6 +4,7 @@
 import { get } from '../../../../lib/request/request-params-builder.js';
 import { safeUrl } from '../../../../lib/utils.js';
 import { CcApiSimpleCommand } from '../../lib/cc-api-command.js';
+import { normalizeMemberKind } from './network-group-utils.js';
 
 /**
  *
@@ -16,6 +17,14 @@ export class GetNetworkGroupCommand extends CcApiSimpleCommand {
   /** @type {CcApiSimpleCommand<GetNetworkGroupCommandInput, GetNetworkGroupCommandOutput>['toRequestParams']} */
   toRequestParams(params) {
     return get(safeUrl`/v4/networkgroups/organisations/${params.ownerId}/networkgroups/${params.networkGroupId}`);
+  }
+
+  /** @type {CcApiSimpleCommand<GetNetworkGroupCommandInput, GetNetworkGroupCommandOutput>['transformCommandOutput']} */
+  transformCommandOutput(response) {
+    return {
+      ...response,
+      members: response.members.map(normalizeMemberKind),
+    };
   }
 
   /** @type {CcApiSimpleCommand<?, ?>['getEmptyResponsePolicy']} */

--- a/src/clients/cc-api/commands/network-group/get-network-group-member-command.js
+++ b/src/clients/cc-api/commands/network-group/get-network-group-member-command.js
@@ -4,6 +4,7 @@
 import { get } from '../../../../lib/request/request-params-builder.js';
 import { safeUrl } from '../../../../lib/utils.js';
 import { CcApiSimpleCommand } from '../../lib/cc-api-command.js';
+import { normalizeMemberKind } from './network-group-utils.js';
 
 /**
  *
@@ -18,6 +19,11 @@ export class GetNetworkGroupMemberCommand extends CcApiSimpleCommand {
     return get(
       safeUrl`/v4/networkgroups/organisations/${params.ownerId}/networkgroups/${params.networkGroupId}/members/${params.memberId}`,
     );
+  }
+
+  /** @type {CcApiSimpleCommand<GetNetworkGroupMemberCommandInput, GetNetworkGroupMemberCommandOutput>['transformCommandOutput']} */
+  transformCommandOutput(response) {
+    return normalizeMemberKind(response);
   }
 
   /** @type {CcApiSimpleCommand<?, ?>['getEmptyResponsePolicy']} */

--- a/src/clients/cc-api/commands/network-group/list-network-group-command.js
+++ b/src/clients/cc-api/commands/network-group/list-network-group-command.js
@@ -1,9 +1,11 @@
 /**
  * @import { ListNetworkGroupCommandInput, ListNetworkGroupCommandOutput } from './list-network-group-command.types.js';
+ * @import { NetworkGroup } from './network-group.types.js';
  */
 import { get } from '../../../../lib/request/request-params-builder.js';
 import { safeUrl } from '../../../../lib/utils.js';
 import { CcApiSimpleCommand } from '../../lib/cc-api-command.js';
+import { normalizeMemberKind } from './network-group-utils.js';
 
 /**
  *
@@ -16,6 +18,16 @@ export class ListNetworkGroupCommand extends CcApiSimpleCommand {
   /** @type {CcApiSimpleCommand<ListNetworkGroupCommandInput, ListNetworkGroupCommandOutput>['toRequestParams']} */
   toRequestParams(params) {
     return get(safeUrl`/v4/networkgroups/organisations/${params.ownerId}/networkgroups`);
+  }
+
+  /** @type {CcApiSimpleCommand<ListNetworkGroupCommandInput, ListNetworkGroupCommandOutput>['transformCommandOutput']} */
+  transformCommandOutput(response) {
+    return response.map(
+      /** @param {NetworkGroup} networkGroup */ (networkGroup) => ({
+        ...networkGroup,
+        members: networkGroup.members.map(normalizeMemberKind),
+      }),
+    );
   }
 
   /** @type {CcApiSimpleCommand<?, ?>['getEmptyResponsePolicy']} */

--- a/src/clients/cc-api/commands/network-group/network-group-utils.js
+++ b/src/clients/cc-api/commands/network-group/network-group-utils.js
@@ -95,6 +95,23 @@ export async function waitForNetworkGroupPeerDeletion(composer, ownerId, network
 }
 
 /**
+ * Returns a copy of the given member with its `kind` normalized to uppercase.
+ *
+ * The Clever Cloud API may return the member `kind` in lower or mixed case; this
+ * guarantees it is always one of `'APPLICATION' | 'ADDON' | 'EXTERNAL'`.
+ *
+ * @template {{ kind: string }} T
+ * @param {T} member
+ * @returns {T & { kind: NetworkGroupMember['kind'] }}
+ */
+export function normalizeMemberKind(member) {
+  return {
+    ...member,
+    kind: /** @type {NetworkGroupMember['kind']} */ (member.kind.toUpperCase()),
+  };
+}
+
+/**
  *
  * @param {string} ngId The Network Group ID
  * @param {string} memberId The member ID

--- a/src/clients/cc-api/commands/network-group/search-network-group-command.js
+++ b/src/clients/cc-api/commands/network-group/search-network-group-command.js
@@ -6,6 +6,7 @@ import { QueryParams } from '../../../../lib/request/query-params.js';
 import { get } from '../../../../lib/request/request-params-builder.js';
 import { safeUrl } from '../../../../lib/utils.js';
 import { CcApiSimpleCommand } from '../../lib/cc-api-command.js';
+import { normalizeMemberKind } from './network-group-utils.js';
 
 /**
  *
@@ -25,11 +26,17 @@ export class SearchNetworkGroupCommand extends CcApiSimpleCommand {
 
   /** @type {CcApiSimpleCommand<SearchNetworkGroupCommandInput, SearchNetworkGroupCommandOutput>['transformCommandOutput']} */
   transformCommandOutput(response) {
+    const normalized = response.map(
+      /** @param {NetworkGroupComponent} item */ (item) => (item.type === 'Member' ? normalizeMemberKind(item) : item),
+    );
+
     if (this.params.types == null || this.params.types.length === 0) {
-      return response;
+      return normalized;
     }
 
-    return response.filter(/** @param {NetworkGroupComponent} item */ (item) => this.params.types.includes(item.type));
+    return normalized.filter(
+      /** @param {NetworkGroupComponent} item */ (item) => this.params.types.includes(item.type),
+    );
   }
 
   /** @type {CcApiSimpleCommand<?, ?>['getEmptyResponsePolicy']} */


### PR DESCRIPTION
## Context

The API used to return `member.kind` fields untouched, in UPPERCASE  but it recently changed and broke a component.
This makes sure `member.kind` is always UPPERCASE.

## How to review?

- 1 reviewer should be enough for this one.