### PR TITLE
ci: add playwright install

### DIFF
--- a/.github/actions/get-playwright-version/action.yml
+++ b/.github/actions/get-playwright-version/action.yml
@@ -1,0 +1,25 @@
+name: Get Playwright version
+description: 'Derive the installed Playwright version so the Playwright Docker image tag stays in sync (run after dependencies are installed)'
+
+outputs:
+  version:
+    description: 'Resolved Playwright version, e.g. 1.60.0'
+    value: ${{ steps.derive.outputs.version }}
+
+runs:
+  using: composite
+  steps:
+    # The Playwright Docker image tag must match the installed Playwright
+    # version, otherwise Playwright throws a version-mismatch error. We derive
+    # it from the installed dependency so it stays in sync automatically and the
+    # container jobs reference it through `needs`.
+    - name: Derive Playwright version
+      id: derive
+      shell: bash
+      run: |
+        PLAYWRIGHT_VERSION="$(pnpm why playwright --depth 0 --json | jq -r '.[0].version')"
+        if ! [[ "$PLAYWRIGHT_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          echo "::error::Unexpected Playwright version: '$PLAYWRIGHT_VERSION'"
+          exit 1
+        fi
+        echo "version=$PLAYWRIGHT_VERSION" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,10 +33,26 @@ jobs:
       - name: '[Code quality] Check format'
         run: pnpm run format:check
 
+  get-playwright-version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.pw.outputs.version }}
+    steps:
+      - name: '[Prepare] Checkout'
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: '[Prepare] Setup'
+        uses: ./.github/actions/ci-setup
+      - name: '[Prepare] Derive Playwright version'
+        id: pw
+        uses: ./.github/actions/get-playwright-version
+
   tests:
+    needs: get-playwright-version
     runs-on: ubuntu-latest
     container:
-      image: mcr.microsoft.com/playwright:v1.60.0-noble
+      image: mcr.microsoft.com/playwright:v${{ needs.get-playwright-version.outputs.version }}-noble
       options: --user 1001
 
     steps:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -12,10 +12,25 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  get-playwright-version:
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'run-e2e-tests')
+    outputs:
+      version: ${{ steps.pw.outputs.version }}
+    steps:
+      - name: '[Prepare] Checkout'
+        uses: actions/checkout@v5
+      - name: '[Prepare] Setup'
+        uses: ./.github/actions/ci-setup
+      - name: '[Prepare] Derive Playwright version'
+        id: pw
+        uses: ./.github/actions/get-playwright-version
+
   test:
+    needs: get-playwright-version
     runs-on: ubuntu-latest
     container:
-      image: mcr.microsoft.com/playwright:v1.60.0-noble
+      image: mcr.microsoft.com/playwright:v${{ needs.get-playwright-version.outputs.version }}-noble
       options: --user 1001
     if: contains(github.event.pull_request.labels.*.name, 'run-e2e-tests')
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,9 +14,29 @@ env:
   NODE_OPTIONS: '--max-old-space-size=16384'
 
 jobs:
+  get-playwright-version:
+    name: 'Get Playwright version'
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.pw.outputs.version }}
+    steps:
+      - name: '[Prepare] Checkout'
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.ref_name }}
+      - name: '[Prepare] Setup'
+        uses: ./.github/actions/ci-setup
+      - name: '[Prepare] Derive Playwright version'
+        id: pw
+        uses: ./.github/actions/get-playwright-version
+
   publish:
     name: 'Publish'
+    needs: get-playwright-version
     runs-on: ubuntu-latest
+    container:
+      image: mcr.microsoft.com/playwright:v${{ needs.get-playwright-version.outputs.version }}-noble
+      options: --user 1001
     steps:
       - name: '[Prepare] Decode version from tag'
         id: version_regex


### PR DESCRIPTION
## Context

- Tests are failing which prevents us from publishing (https://github.com/CleverCloud/clever-client.js/actions/runs/28190059113/job/83501956872),
- Tests now require playwright to be installed in CI and the publish workflow didn't use the playwright container image,
- This PR:
  - Adds a way to retrieve the playwright version and uses it to run on the corresponding playwright image,
  - Adds the playwright image to the publish workflow.

## How to review?

- 1 reviewer should be enough for this one.