### PR TITLE
feat(domains): add domainToUrl helper and fix isTestDomain boundary

### DIFF
--- a/esm/utils/domains.js
+++ b/esm/utils/domains.js
@@ -77,7 +77,7 @@ export function getDomainUrl(hostname, pathPrefix, isWildcard, isHttpOnly) {
  * @return {boolean}
  */
 export function isTestDomain(hostname) {
-  return hostname.endsWith('cleverapps.io');
+  return hostname.endsWith('.cleverapps.io');
 }
 
 /**

--- a/esm/utils/domains.js
+++ b/esm/utils/domains.js
@@ -73,6 +73,21 @@ export function getDomainUrl(hostname, pathPrefix, isWildcard, isHttpOnly) {
 }
 
 /**
+ * Parses a `domainWithPath` and builds its browsable URL in one step.
+ *
+ * The scheme is derived from the domain: test subdomains (e.g. `sub.app.cleverapps.io`)
+ * are HTTP only, everything else uses HTTPS.
+ *
+ * @param {string} domainWithPath
+ * @returns {string}
+ */
+export function domainToUrl(domainWithPath) {
+  const { hostname, pathname, isWildcard } = parseDomain(domainWithPath);
+  const isHttpOnly = isTestDomainWithSubdomain(hostname);
+  return getDomainUrl(hostname, pathname, isWildcard, isHttpOnly);
+}
+
+/**
  * @param {string} hostname
  * @return {boolean}
  */

--- a/test/unit/esm/utils/domains.spec.js
+++ b/test/unit/esm/utils/domains.spec.js
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   DomainParseError,
+  domainToUrl,
   getDomainUrl,
   getHostWithWildcard,
   isTestDomain,
@@ -116,6 +117,29 @@ describe('domains', () => {
     it('should include www for wildcard domains', () => {
       const wildcardUrl = getDomainUrl('example.com', '/path', true, false);
       expect(wildcardUrl).toBe('https://www.example.com/path');
+    });
+  });
+
+  describe('domainToUrl()', () => {
+    it('should build an HTTPS URL from a simple domain with path', () => {
+      const url = domainToUrl('example.com/path');
+      expect(url).toBe('https://example.com/path');
+    });
+
+    it('should build a www HTTPS URL from a wildcard domain', () => {
+      const url = domainToUrl('*.example.com');
+      expect(url).toBe('https://www.example.com/');
+    });
+
+    it('should derive an HTTP URL for a test subdomain', () => {
+      const url = domainToUrl('sub.app.cleverapps.io');
+      expect(url).toBe('http://sub.app.cleverapps.io/');
+    });
+
+    it('should throw DomainParseError for an invalid domain', () => {
+      const domainToUrlCallback = () => domainToUrl('');
+      expect(domainToUrlCallback).toThrow(DomainParseError);
+      expect(domainToUrlCallback).toThrow(expect.objectContaining({ code: 'empty' }));
     });
   });
 

--- a/test/unit/esm/utils/domains.spec.js
+++ b/test/unit/esm/utils/domains.spec.js
@@ -129,6 +129,11 @@ describe('domains', () => {
       const isTestDomainResult = isTestDomain('example.com');
       expect(isTestDomainResult).toBe(false);
     });
+
+    it('should return false for domain ending with cleverapps.io without a label boundary', () => {
+      const isTestDomainResult = isTestDomain('mycleverapps.io');
+      expect(isTestDomainResult).toBe(false);
+    });
   });
 
   describe('isTestDomainWithSubdomain()', () => {


### PR DESCRIPTION
## Context

The console (and likely other consumers) builds browsable URLs by wiring `parseDomain` + `getDomainUrl` manually, importing these helpers from `@clevercloud/components/dist/lib/domain.js` instead of the client:

```js
const { hostname, pathname, isWildcard } = parseDomain(domainWithPath);
return getDomainUrl(hostname, pathname, isWildcard, false);
```

Two issues surfaced from this:

- there is no single helper combining `parseDomain` + `getDomainUrl`, so callers repeat the boilerplate;
- `isTestDomain` matched any hostname *ending* with `cleverapps.io`, so unrelated domains like `mycleverapps.io` were wrongly considered test domains.

## Proposal

- **`fix(domains)`** — `isTestDomain` now anchors on the label boundary (`.cleverapps.io`) instead of a raw `endsWith('cleverapps.io')`.
- **`feat(domains)`** — add `domainToUrl(domainWithPath)` that runs `parseDomain` then `getDomainUrl` in one step and derives the scheme itself.

### Design decision — single argument, no `isHttpOnly` override

The helper takes only `domainWithPath` and decides the scheme on its own:

```js
const isHttpOnly = isTestDomainWithSubdomain(hostname);
```

- test subdomains (e.g. `sub.app.cleverapps.io`) → `http://` (they are HTTP only);
- everything else → `https://`.

No `isHttpOnly` parameter is exposed: it would be redundant with this derivation and re-introduce the exact footgun the helper is meant to remove (a caller passing the wrong flag → broken URL). Callers needing full control over the scheme can still drop down to the low-level `getDomainUrl`, which keeps its explicit `isHttpOnly` argument.

### Behavior change

- `isTestDomain('mycleverapps.io')` → `false` (was `true`)
- `isTestDomain('cleverapps.io')` → `false` (was `true`) — bare apex no longer counts, only real subdomains match
- `domainToUrl('sub.app.cleverapps.io')` → `http://sub.app.cleverapps.io/` (scheme derived, no flag needed)

## How to test

```
npm run test:unit:node -- test/unit/esm/utils/domains.spec.js
```

New/updated specs cover the label boundary and `domainToUrl` (simple, wildcard → `www.`, derived http-only for a test subdomain, invalid fqdn).

## Follow-up (out of scope)

- Migrate console call sites to import `domainToUrl` from `@clevercloud/client` and drop the local helper.
- Update `clever-components` accordingly: align its `dist/lib/domain.js` helpers on this client (consume `domainToUrl`, port the `isTestDomain` boundary fix) and drop the duplicated logic.
