### PR TITLE
fix: never cache 5xx responses or promise rejections in request caching

### DIFF
--- a/esm/with-cache.ts
+++ b/esm/with-cache.ts
@@ -17,6 +17,12 @@ function getKey(cacheParams: Record<string, any>): string {
   return JSON.stringify(objectKey);
 }
 
+function safeDeleteFromCache<T>(cacheKey: string, promise: Promise<T>) {
+  if (cache.get(cacheKey) === promise) {
+    cache.delete(cacheKey);
+  }
+}
+
 export const NO_CACHE = 0;
 export const ONE_SECOND = 1000;
 export const ONE_DAY = 1000 * 60 * 60 * 24;
@@ -32,12 +38,17 @@ export function withCache<T>(
     return cache.get(cacheKey);
   }
 
-  const promise = createPromise();
+  // never cache a rejection: drop it immediately so the next call retries
+  const promise = createPromise().catch((error) => {
+    safeDeleteFromCache(cacheKey, promise);
+    throw error;
+  });
 
   if (cacheParams.method === 'get' && cacheDelay !== NO_CACHE) {
     cache.set(cacheKey, promise);
     setTimeout(() => {
-      cache.delete(cacheKey);
+      // identity guard: don't evict a newer entry that replaced this one after a retry
+      safeDeleteFromCache(cacheKey, promise);
     }, cacheDelay);
   }
 

--- a/src/lib/request/request-with-cache.ts
+++ b/src/lib/request/request-with-cache.ts
@@ -32,7 +32,8 @@ export async function requestWithCache<CommandOutput>(
   // cache miss
   const response = await handler<CommandOutput>(request);
 
-  if (request.cache.ttl > 0) {
+  // store to cache (but never cache a 5xx response)
+  if (request.cache.ttl > 0 && response.status < 500) {
     CACHE.set(cacheKey, {
       response: { ...response, cacheHit: true },
       expiresAt: Date.now() + request.cache.ttl,

--- a/test/unit/esm/with-cache.spec.ts
+++ b/test/unit/esm/with-cache.spec.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+import { NO_CACHE, withCache } from '../../../esm/with-cache.js';
+
+describe('withCache()', () => {
+  it('does not cache a rejected promise: the next call retries', async () => {
+    const cacheParams = { method: 'get', url: '/v2/test-rejection' };
+    let attempts = 0;
+    const createPromise = () => {
+      attempts++;
+      return Promise.reject(new Error('transient error'));
+    };
+
+    await withCache(cacheParams, 1000, createPromise).catch(() => {});
+    await withCache(cacheParams, 1000, createPromise).catch(() => {});
+    await withCache(cacheParams, 1000, createPromise).catch(() => {});
+
+    expect(attempts).toBe(3);
+  });
+
+  it('caches a fulfilled promise: the next call reuses it', async () => {
+    const cacheParams = { method: 'get', url: '/v2/test-fulfillment' };
+    let attempts = 0;
+    const createPromise = () => {
+      attempts++;
+      return Promise.resolve('ok');
+    };
+
+    const result1 = await withCache(cacheParams, 1000, createPromise);
+    const result2 = await withCache(cacheParams, 1000, createPromise);
+
+    expect(attempts).toBe(1);
+    expect(result1).toBe('ok');
+    expect(result2).toBe('ok');
+  });
+
+  it('shares one in-flight promise between concurrent callers', async () => {
+    const cacheParams = { method: 'get', url: '/v2/test-dedupe' };
+    let attempts = 0;
+    const createPromise = () => {
+      attempts++;
+      return Promise.resolve('ok');
+    };
+
+    const [result1, result2] = await Promise.all([
+      withCache(cacheParams, 1000, createPromise),
+      withCache(cacheParams, 1000, createPromise),
+    ]);
+
+    expect(attempts).toBe(1);
+    expect(result1).toBe('ok');
+    expect(result2).toBe('ok');
+  });
+
+  it('does not cache anything when cacheDelay is NO_CACHE', async () => {
+    const cacheParams = { method: 'get', url: '/v2/test-no-cache' };
+    let attempts = 0;
+    const createPromise = () => {
+      attempts++;
+      return Promise.resolve('ok');
+    };
+
+    await withCache(cacheParams, NO_CACHE, createPromise);
+    await withCache(cacheParams, NO_CACHE, createPromise);
+
+    expect(attempts).toBe(2);
+  });
+
+  it('a retried entry survives the original failed call stale eviction timer (identity guard)', async () => {
+    const cacheParams = { method: 'get', url: '/v2/test-identity-guard' };
+    const cacheDelay = 60;
+    let attempts = 0;
+    const createPromise = () => {
+      attempts++;
+      return attempts === 1 ? Promise.reject(new Error('transient error')) : Promise.resolve('ok');
+    };
+
+    // t=0: fails, evicted right away by the rejection handler
+    await withCache(cacheParams, cacheDelay, createPromise).catch(() => {});
+
+    // t=25: retry succeeds and schedules its own eviction timer for t=85
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    const retried = await withCache(cacheParams, cacheDelay, createPromise);
+    expect(retried).toBe('ok');
+    expect(attempts).toBe(2);
+
+    // t=70: past the first call's stale timer (t=60), but before the retry's own timer (t=85)
+    await new Promise((resolve) => setTimeout(resolve, 45));
+    const stillCached = await withCache(cacheParams, cacheDelay, createPromise);
+    expect(stillCached).toBe('ok');
+    expect(attempts).toBe(2); // the stale timer must not have evicted the retried entry
+
+    // t=95: past the retry's own timer (t=85): the entry legitimately expires now
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    const fresh = await withCache(cacheParams, cacheDelay, createPromise);
+    expect(fresh).toBe('ok');
+    expect(attempts).toBe(3);
+  });
+});

--- a/test/unit/lib/request/request.spec.ts
+++ b/test/unit/lib/request/request.spec.ts
@@ -476,6 +476,110 @@ describe('request', () => {
       expect(spy).toHaveBeenCalledTimes(0);
       expect(response.body).toEqual(responseBody);
     });
+
+    it('should NOT cache a 5xx response', async () => {
+      await newScenario()
+        .when({ method: 'GET', path: '/api/test-5xx' })
+        .respond({ status: 503, body: { message: 'transient error' } });
+      await sendRequest({
+        method: 'GET',
+        url: `/api/test-5xx`,
+        headers: new HeadersBuilder().acceptJson().build(),
+        cache: { ttl: 1000 },
+      });
+
+      const spy = vi.spyOn(globalThis, 'fetch');
+
+      const response = await sendRequest({
+        method: 'GET',
+        url: `/api/test-5xx`,
+        headers: new HeadersBuilder().acceptJson().build(),
+        cache: { ttl: 1000 },
+      });
+
+      // a 5xx must be retried, never replayed from cache
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(response.status).toBe(503);
+    });
+
+    it('should still cache a 4xx response', async () => {
+      const responseBody = { message: 'not found' };
+      await newScenario().when({ method: 'GET', path: '/api/test-4xx' }).respond({ status: 404, body: responseBody });
+      await sendRequest({
+        method: 'GET',
+        url: `/api/test-4xx`,
+        headers: new HeadersBuilder().acceptJson().build(),
+        cache: { ttl: 1000 },
+      });
+
+      const spy = vi.spyOn(globalThis, 'fetch');
+
+      const response = await sendRequest({
+        method: 'GET',
+        url: `/api/test-4xx`,
+        headers: new HeadersBuilder().acceptJson().build(),
+        cache: { ttl: 1000 },
+      });
+
+      expect(spy).toHaveBeenCalledTimes(0);
+      expect(response.status).toBe(404);
+      expect(response.body).toEqual(responseBody);
+    });
+
+    it('a retried entry after a 5xx is cached and expires on its own schedule', async () => {
+      const ttl = 500;
+      const responseBody = { data: 'ok' };
+
+      // first call gets the 503, every subsequent one gets the 200 (last response repeats
+      // once the array is exhausted)
+      await newScenario()
+        .when({ method: 'GET', path: '/api/test-retry-after-5xx' })
+        .respond([
+          { status: 503, body: { message: 'transient error' } },
+          { status: 200, body: responseBody },
+        ]);
+
+      const failed = await sendRequest({
+        method: 'GET',
+        url: `/api/test-retry-after-5xx`,
+        headers: new HeadersBuilder().acceptJson().build(),
+        cache: { ttl },
+      });
+      expect(failed.status).toBe(503);
+
+      const spy = vi.spyOn(globalThis, 'fetch');
+
+      const retried = await sendRequest({
+        method: 'GET',
+        url: `/api/test-retry-after-5xx`,
+        headers: new HeadersBuilder().acceptJson().build(),
+        cache: { ttl },
+      });
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(retried.status).toBe(200);
+
+      // still within ttl: served from cache, unaffected by the earlier 503
+      const cached = await sendRequest({
+        method: 'GET',
+        url: `/api/test-retry-after-5xx`,
+        headers: new HeadersBuilder().acceptJson().build(),
+        cache: { ttl },
+      });
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(cached.body).toEqual(responseBody);
+
+      // past its own ttl: expires and refetches normally
+      await new Promise((resolve) => setTimeout(resolve, ttl + 150));
+
+      const fresh = await sendRequest({
+        method: 'GET',
+        url: `/api/test-retry-after-5xx`,
+        headers: new HeadersBuilder().acceptJson().build(),
+        cache: { ttl },
+      });
+      expect(spy).toHaveBeenCalledTimes(2);
+      expect(fresh.status).toBe(200);
+    });
   });
 
   describe('dedupe', () => {

--- a/test/unit/lib/request/request.spec.ts
+++ b/test/unit/lib/request/request.spec.ts
@@ -580,6 +580,41 @@ describe('request', () => {
       expect(spy).toHaveBeenCalledTimes(2);
       expect(fresh.status).toBe(200);
     });
+
+    it('should NOT cache a network-level rejection: the next call retries', async () => {
+      const responseBody = { data: 'ok' };
+      await newScenario()
+        .when({ method: 'GET', path: '/api/test-network-error' })
+        .respond({ status: 200, body: responseBody });
+
+      vi.spyOn(globalThis, 'fetch').mockImplementationOnce(() => {
+        throw new TypeError('Failed to fetch');
+      });
+
+      await expectPromiseThrows(
+        sendRequest({
+          method: 'GET',
+          url: `/api/test-network-error`,
+          headers: new HeadersBuilder().acceptJson().build(),
+          cache: { ttl: 1000 },
+        }),
+        (error: CcRequestError) => {
+          expect(error).toBeInstanceOf(CcRequestError);
+          expect(error.code).toBe('NETWORK_ERROR');
+        },
+      );
+
+      // the rejected request must not have been cached: this call hits the network again
+      const response = await sendRequest({
+        method: 'GET',
+        url: `/api/test-network-error`,
+        headers: new HeadersBuilder().acceptJson().build(),
+        cache: { ttl: 1000 },
+      });
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual(responseBody);
+    });
   });
 
   describe('dedupe', () => {


### PR DESCRIPTION
## Context

Fixes #226. Both request-caching layers stored a result in the cache before it was known
to be good: `esm/with-cache.ts` caches the promise synchronously, before it settles, and
`src/lib/request/request-with-cache.ts` caches any HTTP response regardless of status. A
single transient failure (network blip, 5xx, timeout) was therefore replayed to every
caller for the whole cache TTL — with `ONE_DAY` that's 24h stuck on one failed request,
with no retry. In Clever Cloud console's creation tunnels, this left catalog GETs
(`getAllAddonProviders`, `getEsOptionsFlavors`, `getAvailableInstances`) stuck in an error
state for up to a day after a single failed first load.

## Changes

- `esm/with-cache.ts`: evict the cache entry as soon as the promise rejects, so the next
  call retries instead of replaying the same rejection. In-flight de-dup for concurrent
  callers is preserved.
- `src/lib/request/request-with-cache.ts`: skip caching when the response status is 5xx.
  4xx stays cacheable on purpose — commands already treat statuses like 404 as legitimate,
  deterministic answers via `getEmptyResponsePolicy`.
- Tests for both layers, including a network-level (non-HTTP) rejection case and a
  retry-lifecycle case that exercises the eviction-timer identity guard.

### Implementation notes

Evicting on rejection means the fixed `setTimeout(cacheDelay)` eviction timer can no longer
unconditionally delete the key: if a retry repopulates the same key inside the original
failed attempt's window, that timer would fire later and clobber the retried (good) entry.
The timer is now identity-guarded (`cache.get(cacheKey) === promise`) so it only evicts the
entry it actually scheduled.

## How to review

1. Start with `esm/with-cache.ts` — the identity-guard comment explains the subtlety;
   `test/unit/esm/with-cache.spec.ts`'s "survives the original failed call stale eviction
   timer" test exercises exactly that race.
2. Then `src/lib/request/request-with-cache.ts` (one-line status check) and its tests in
   `test/unit/lib/request/request.spec.ts` — 5xx not cached, 4xx still cached, retry-after-
   5xx caches and expires on its own schedule.
3. `pnpm run test:unit:node` covers both files.

**1 approval** to merge.